### PR TITLE
feat: Filter peaks by height and fwhm in pickSpectrum

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/SpectrumExtractor.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/SpectrumExtractor.h
@@ -106,6 +106,15 @@ public:
     void setSignalToNoise(const double& signal_to_noise);
     double getSignalToNoise() const;
 
+    void setPeakHeightMin(const double& peak_height_min);
+    double getPeakHeightMin() const;
+
+    void setPeakHeightMax(const double& peak_height_max);
+    double getPeakHeightMax() const;
+
+    void setFWHMThreshold(const double& fwhm_threshold);
+    double getFWHMThreshold() const;
+
     void setTICWeight(const double& tic_weight);
     double getTICWeight() const;
 
@@ -126,6 +135,7 @@ public:
       sgolay_frame_length_ and sgolay_polynomial_order_ through their setters.
       The peak picking is executed with PeakPickerHiRes. It's possible to set the
       signal_to_noise_ parameter.
+      Peaks are then filtered by their heights and FWHM values (setters are provided).
 
       @param[in] spectrum The input spectrum
       @param[out] picked_spectrum A spectrum containing only the picked peaks
@@ -139,6 +149,8 @@ public:
       The spectra taken into account are those that fall within the precursor RT
       window and MZ tolerance set by the user through the setRTWindows() and
       setMZTolerance setters. Default values are provided for both parameters.
+
+      @warning The picked spectrum could be empty, meaning no peaks were found.
 
       @param[in] spectra The spectra to filter
       @param[in] targeted_exp The target list
@@ -167,14 +179,14 @@ public:
 
       @param[in] annotated_spectra The annotated spectra to score (for TIC and SNR)
       @param[in] picked_spectra The picked peaks found on each of the annotated spectra (for FWHM)
+      @param[in,out] features The score informations are also added to this FeatureMap. Picked peaks' FWHMs are saved in features' subordinates.
       @param[out] scored_spectra The scored spectra. Basically a copy of annotated_spectra with the added score informations
-      @param[out] features The score informations are also added to this FeatureMap. Picked peaks' FWHMs are saved in features' subordinates.
     */
     void scoreSpectra(
       const std::vector<MSSpectrum>& annotated_spectra,
       const std::vector<MSSpectrum>& picked_spectra,
-      std::vector<MSSpectrum>& scored_spectra,
-      FeatureMap& features
+      FeatureMap& features,
+      std::vector<MSSpectrum>& scored_spectra
     );
 
     /**
@@ -204,14 +216,14 @@ public:
       annotation (i.e., transition name)
 
       @param[in] scored_spectra Input annotated and scored spectra
-      @param[out] selected_spectra Output selected spectra
       @param[in] features Input features
+      @param[out] selected_spectra Output selected spectra
       @param[out] selected_features Output selected features
     */
     void selectSpectra(
       const std::vector<MSSpectrum>& scored_spectra,
-      std::vector<MSSpectrum>& selected_spectra,
       const FeatureMap& features,
+      std::vector<MSSpectrum>& selected_spectra,
       FeatureMap& selected_features
     );
 
@@ -245,6 +257,11 @@ private:
     double gauss_width_; /**< Use a gaussian filter width which has approximately the same width as your mass peaks (FWHM in m/z) */
     bool use_gauss_; /**< Set to false if you want to use the Savitzky-Golay filtering method */
     double signal_to_noise_; /**< Minimal signal-to-noise ratio for a peak to be picked (0.0 disables SNT estimation!) */
+
+    // peak picking
+    double peak_height_min_; /**< Minimum picked peak's height */
+    double peak_height_max_; /**< Maximum picked peak's height */
+    double fwhm_threshold_; /**< Picked peak's FWHM threshold */
 
     // scoring
     double tic_weight_; /**< Total TIC's weight when computing a spectrum's score */

--- a/src/openms/source/ANALYSIS/OPENSWATH/SpectrumExtractor.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/SpectrumExtractor.cpp
@@ -273,7 +273,7 @@ namespace OpenMS
 
     params.setValue("peak_height_min", 0.0, "Minimum picked peak's height.");
     params.setMinFloat("peak_height_min", 0.0);
-    params.setValue("peak_height_max", 1000000.0, "Maximum picked peak's height.");
+    params.setValue("peak_height_max", 4e6, "Maximum picked peak's height.");
     params.setMinFloat("peak_height_max", 0.0);
     params.setValue("fwhm_threshold", 0.0, "Picked peak's FWHM threshold.");
     params.setMinFloat("fwhm_threshold", 0.0);

--- a/src/openms/source/ANALYSIS/OPENSWATH/SpectrumExtractor.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/SpectrumExtractor.cpp
@@ -157,6 +157,36 @@ namespace OpenMS
     return signal_to_noise_;
   }
 
+  void SpectrumExtractor::setPeakHeightMin(const double& peak_height_min)
+  {
+    peak_height_min_ = peak_height_min;
+  }
+
+  double SpectrumExtractor::getPeakHeightMin() const
+  {
+    return peak_height_min_;
+  }
+
+  void SpectrumExtractor::setPeakHeightMax(const double& peak_height_max)
+  {
+    peak_height_max_ = peak_height_max;
+  }
+
+  double SpectrumExtractor::getPeakHeightMax() const
+  {
+    return peak_height_max_;
+  }
+
+  void SpectrumExtractor::setFWHMThreshold(const double& fwhm_threshold)
+  {
+    fwhm_threshold_ = fwhm_threshold;
+  }
+
+  double SpectrumExtractor::getFWHMThreshold() const
+  {
+    return fwhm_threshold_;
+  }
+
   void SpectrumExtractor::setTICWeight(const double& tic_weight)
   {
     tic_weight_ = tic_weight;
@@ -202,6 +232,10 @@ namespace OpenMS
     use_gauss_ = (bool)param_.getValue("use_gauss").toBool();
     signal_to_noise_ = (double)param_.getValue("signal_to_noise");
 
+    peak_height_min_ = (double)param_.getValue("peak_height_min");
+    peak_height_max_ = (double)param_.getValue("peak_height_max");
+    fwhm_threshold_ = (double)param_.getValue("fwhm_threshold");
+
     tic_weight_ = (double)param_.getValue("tic_weight");
     fwhm_weight_ = (double)param_.getValue("fwhm_weight");
     snr_weight_ = (double)param_.getValue("snr_weight");
@@ -211,7 +245,7 @@ namespace OpenMS
   {
     params.clear();
 
-    params.setValue("rt_window", 30, "Retention time window in seconds.");
+    params.setValue("rt_window", 30.0, "Retention time window in seconds.");
 
     params.setValue("min_score", 0.7, "The minimum score a spectrum must have to be assignable to a transition.");
     params.setMinFloat("min_score", 0.0);
@@ -236,6 +270,13 @@ namespace OpenMS
     params.setValidStrings("use_gauss", ListUtils::create<String>("false,true"));
     params.setValue("signal_to_noise", 1.0, "Signal-to-noise threshold at which a peak will not be extended any more. Note that setting this too high (e.g. 1.0) can lead to peaks whose flanks are not fully captured.");
     params.setMinFloat("signal_to_noise", 0.0);
+
+    params.setValue("peak_height_min", 0.0, "Minimum picked peak's height.");
+    params.setMinFloat("peak_height_min", 0.0);
+    params.setValue("peak_height_max", 1000000.0, "Maximum picked peak's height.");
+    params.setMinFloat("peak_height_max", 0.0);
+    params.setValue("fwhm_threshold", 0.0, "Picked peak's FWHM threshold.");
+    params.setMinFloat("fwhm_threshold", 0.0);
 
     params.setValue("tic_weight", 1.0, "TIC weight when scoring spectra.");
     params.setMinFloat("tic_weight", 0.0);
@@ -263,7 +304,15 @@ namespace OpenMS
 
     // Smooth the spectrum
     MSSpectrum smoothed_spectrum = spectrum;
-    if (!use_gauss_)
+    if (getUseGauss())
+    {
+      GaussFilter gauss;
+      Param filter_parameters = gauss.getParameters();
+      filter_parameters.setValue("gaussian_width", gauss_width_);
+      gauss.setParameters(filter_parameters);
+      gauss.filter(smoothed_spectrum);
+    }
+    else
     {
       SavitzkyGolayFilter sgolay;
       Param filter_parameters = sgolay.getParameters();
@@ -271,14 +320,6 @@ namespace OpenMS
       filter_parameters.setValue("polynomial_order", sgolay_polynomial_order_);
       sgolay.setParameters(filter_parameters);
       sgolay.filter(smoothed_spectrum);
-    }
-    else
-    {
-      GaussFilter gauss;
-      Param filter_parameters = gauss.getParameters();
-      filter_parameters.setValue("gaussian_width", gauss_width_);
-      gauss.setParameters(filter_parameters);
-      gauss.filter(smoothed_spectrum);
     }
 
     // Find initial seeds (peak picking)
@@ -293,7 +334,32 @@ namespace OpenMS
     PeakPickerHiRes pp;
     pp.setParameters(pepi_param);
     pp.pick(smoothed_spectrum, picked_spectrum);
-    LOG_DEBUG << "Found " << picked_spectrum.size() << " spectrum peaks." << std::endl;
+
+    std::vector<UInt> peaks_pos_to_erase;
+    for (Int i=picked_spectrum.size()-1; i>=0; --i)
+    {
+      if (picked_spectrum[i].getIntensity() < getPeakHeightMin() ||
+          picked_spectrum[i].getIntensity() > getPeakHeightMax() ||
+          picked_spectrum.getFloatDataArrays()[0][i] < getFWHMThreshold())
+      {
+        peaks_pos_to_erase.push_back(i);
+      }
+    }
+
+    if (peaks_pos_to_erase.size() != picked_spectrum.size()) // if not all peaks are to be removed
+    {
+      for (auto i : peaks_pos_to_erase) // then keep only the valid peaks (and fwhm)
+      {
+        picked_spectrum.erase(picked_spectrum.begin() + i);
+        picked_spectrum.getFloatDataArrays()[0].erase(picked_spectrum.getFloatDataArrays()[0].begin() + i);
+      }
+    }
+    else // otherwise output an empty picked_spectrum
+    {
+      picked_spectrum.clear(true);
+    }
+
+    LOG_DEBUG << "Found " << picked_spectrum.size() << " peaks." << std::endl;
   }
 
   void SpectrumExtractor::annotateSpectra(
@@ -351,8 +417,8 @@ namespace OpenMS
   void SpectrumExtractor::scoreSpectra(
     const std::vector<MSSpectrum>& annotated_spectra,
     const std::vector<MSSpectrum>& picked_spectra,
-    std::vector<MSSpectrum>& scored_spectra,
-    FeatureMap& features
+    FeatureMap& features,
+    std::vector<MSSpectrum>& scored_spectra
   )
   {
     scored_spectra.clear();
@@ -440,17 +506,28 @@ namespace OpenMS
       pickSpectrum(annotated[i], picked[i]);
     }
 
+    // remove empty picked<> spectra, and accordingly update annotated<> and features
+    for (Int i=annotated.size()-1; i>=0; --i)
+    {
+      if (!picked[i].size())
+      {
+        annotated.erase(annotated.begin() + i);
+        picked.erase(picked.begin() + i);
+        features.erase(features.begin() + i);
+      }
+    }
+
     // score spectra
     std::vector<MSSpectrum> scored;
-    scoreSpectra(annotated, picked, scored, features);
+    scoreSpectra(annotated, picked, features, scored);
 
-    selectSpectra(scored, extracted_spectra, features, extracted_features);
+    selectSpectra(scored, features, extracted_spectra, extracted_features);
   }
 
   void SpectrumExtractor::selectSpectra(
     const std::vector<MSSpectrum>& scored_spectra,
-    std::vector<MSSpectrum>& selected_spectra,
     const FeatureMap& features,
+    std::vector<MSSpectrum>& selected_spectra,
     FeatureMap& selected_features
   )
   {
@@ -498,6 +575,6 @@ namespace OpenMS
   {
     FeatureMap dummy_features;
     FeatureMap dummy_selected_features;
-    selectSpectra(scored_spectra, selected_spectra, dummy_features, dummy_selected_features);
+    selectSpectra(scored_spectra, dummy_features, selected_spectra, dummy_selected_features);
   }
 }

--- a/src/tests/class_tests/openms/source/SpectrumExtractor_test.cpp
+++ b/src/tests/class_tests/openms/source/SpectrumExtractor_test.cpp
@@ -326,7 +326,7 @@ START_SECTION(getParameters())
   TEST_EQUAL(params.getValue("use_gauss"), "true")
   TEST_EQUAL(params.getValue("signal_to_noise"), 1.0)
   TEST_EQUAL(params.getValue("peak_height_min"), 0.0)
-  TEST_EQUAL(params.getValue("peak_height_max"), 1000000.0)
+  TEST_EQUAL(params.getValue("peak_height_max"), 4e6)
   TEST_EQUAL(params.getValue("fwhm_threshold"), 0.0)
   TEST_EQUAL(params.getValue("tic_weight"), 1.0)
   TEST_EQUAL(params.getValue("fwhm_weight"), 1.0)
@@ -433,7 +433,7 @@ END_SECTION
 
 START_SECTION(getPeakHeightMax())
 {
-  TEST_EQUAL(ptr->getPeakHeightMax(), 1000000.0)
+  TEST_EQUAL(ptr->getPeakHeightMax(), 4e6)
   ptr->setPeakHeightMax(150000.0);
   TEST_EQUAL(ptr->getPeakHeightMax(), 150000.0)
 }

--- a/src/tests/class_tests/openms/source/SpectrumExtractor_test.cpp
+++ b/src/tests/class_tests/openms/source/SpectrumExtractor_test.cpp
@@ -314,7 +314,7 @@ ptr = new SpectrumExtractor();
 START_SECTION(getParameters())
 {
   Param params = ptr->getParameters();
-  TEST_EQUAL(params.getValue("rt_window"), 30)
+  TEST_EQUAL(params.getValue("rt_window"), 30.0)
   TEST_EQUAL(params.getValue("min_score"), 0.7)
   TEST_EQUAL(params.getValue("min_forward_match"), 0.9)
   TEST_EQUAL(params.getValue("min_reverse_match"), 0.9)
@@ -325,6 +325,9 @@ START_SECTION(getParameters())
   TEST_EQUAL(params.getValue("gauss_width"), 0.2)
   TEST_EQUAL(params.getValue("use_gauss"), "true")
   TEST_EQUAL(params.getValue("signal_to_noise"), 1.0)
+  TEST_EQUAL(params.getValue("peak_height_min"), 0.0)
+  TEST_EQUAL(params.getValue("peak_height_max"), 1000000.0)
+  TEST_EQUAL(params.getValue("fwhm_threshold"), 0.0)
   TEST_EQUAL(params.getValue("tic_weight"), 1.0)
   TEST_EQUAL(params.getValue("fwhm_weight"), 1.0)
   TEST_EQUAL(params.getValue("snr_weight"), 1.0)
@@ -333,9 +336,9 @@ END_SECTION
 
 START_SECTION(setRTWindow())
 {
-  TEST_EQUAL(ptr->getRTWindow(), 30)
-  ptr->setRTWindow(50);
-  TEST_EQUAL(ptr->getRTWindow(), 50)
+  TEST_EQUAL(ptr->getRTWindow(), 30.0)
+  ptr->setRTWindow(50.0);
+  TEST_EQUAL(ptr->getRTWindow(), 50.0)
 }
 END_SECTION
 
@@ -420,6 +423,30 @@ START_SECTION(setSignalToNoise())
 }
 END_SECTION
 
+START_SECTION(getPeakHeightMin())
+{
+  TEST_EQUAL(ptr->getPeakHeightMin(), 0.0)
+  ptr->setPeakHeightMin(0.6);
+  TEST_EQUAL(ptr->getPeakHeightMin(), 0.6)
+}
+END_SECTION
+
+START_SECTION(getPeakHeightMax())
+{
+  TEST_EQUAL(ptr->getPeakHeightMax(), 1000000.0)
+  ptr->setPeakHeightMax(150000.0);
+  TEST_EQUAL(ptr->getPeakHeightMax(), 150000.0)
+}
+END_SECTION
+
+START_SECTION(getFWHMThreshold())
+{
+  TEST_EQUAL(ptr->getFWHMThreshold(), 0.0)
+  ptr->setFWHMThreshold(0.23);
+  TEST_EQUAL(ptr->getFWHMThreshold(), 0.23)
+}
+END_SECTION
+
 START_SECTION(getParameters().getDescription("rt_window"))
 {
   TEST_EQUAL(ptr->getParameters().getDescription("rt_window"), "Retention time window in seconds.")
@@ -454,29 +481,59 @@ START_SECTION(pickSpectrum())
 {
   MSSpectrum picked_spectrum;
   spectrum.sortByPosition();
-  ptr->setGaussWidth(0.2);
+
   ptr->setUseGauss(true);
+  ptr->setGaussWidth(0.25);
+  ptr->setPeakHeightMin(0.0);
+  ptr->setPeakHeightMax(200000.0);
+  ptr->setFWHMThreshold(0.0);
   ptr->pickSpectrum(spectrum, picked_spectrum);
   TEST_NOT_EQUAL(spectrum.size(), picked_spectrum.size())
-
+  TEST_EQUAL(picked_spectrum.size(), 6)
   MSSpectrum::Iterator it = picked_spectrum.begin();
   TEST_REAL_SIMILAR(it->getMZ(), 85.014)
-  TEST_REAL_SIMILAR(it->getIntensity(), 60774.2)
+  TEST_REAL_SIMILAR(it->getIntensity(), 60754.7)
   ++it;
   TEST_REAL_SIMILAR(it->getMZ(), 86.0196)
-  TEST_REAL_SIMILAR(it->getIntensity(), 116084)
+  TEST_REAL_SIMILAR(it->getIntensity(), 116036.0)
   ++it;
   TEST_REAL_SIMILAR(it->getMZ(), 112.033)
-  TEST_REAL_SIMILAR(it->getIntensity(), 21948.4)
+  TEST_REAL_SIMILAR(it->getIntensity(), 21941.9)
   ++it;
   TEST_REAL_SIMILAR(it->getMZ(), 129.396)
-  TEST_REAL_SIMILAR(it->getIntensity(), 10570)
+  TEST_REAL_SIMILAR(it->getIntensity(), 10575.5)
   ++it;
   TEST_REAL_SIMILAR(it->getMZ(), 130.081)
-  TEST_REAL_SIMILAR(it->getIntensity(), 31851.7)
+  TEST_REAL_SIMILAR(it->getIntensity(), 31838.1)
   ++it;
-  TEST_REAL_SIMILAR(it->getMZ(), 174.239)
-  TEST_REAL_SIMILAR(it->getIntensity(), 11734.7)
+  TEST_REAL_SIMILAR(it->getMZ(), 174.24)
+  TEST_REAL_SIMILAR(it->getIntensity(), 11731.3)
+
+  ptr->setPeakHeightMin(15000.0);
+  ptr->setPeakHeightMax(110000.0);
+  ptr->pickSpectrum(spectrum, picked_spectrum);
+  // With the new filters on peaks' heights, less peaks get picked.
+  TEST_EQUAL(picked_spectrum.size(), 3)
+  it = picked_spectrum.begin();
+  TEST_REAL_SIMILAR(it->getMZ(), 85.014)
+  TEST_REAL_SIMILAR(it->getIntensity(), 60754.7)
+  ++it;
+  TEST_REAL_SIMILAR(it->getMZ(), 112.033)
+  TEST_REAL_SIMILAR(it->getIntensity(), 21941.9)
+  ++it;
+  TEST_REAL_SIMILAR(it->getMZ(), 130.081)
+  TEST_REAL_SIMILAR(it->getIntensity(), 31838.1)
+
+  ptr->setFWHMThreshold(0.23);
+  ptr->pickSpectrum(spectrum, picked_spectrum);
+  // Filtering also on fwhm, even less peaks get picked.
+  TEST_EQUAL(picked_spectrum.size(), 2)
+  it = picked_spectrum.begin();
+  TEST_REAL_SIMILAR(it->getMZ(), 85.014)
+  TEST_REAL_SIMILAR(it->getIntensity(), 60754.7)
+  ++it;
+  TEST_REAL_SIMILAR(it->getMZ(), 112.033)
+  TEST_REAL_SIMILAR(it->getIntensity(), 21941.9)
 }
 END_SECTION
 
@@ -487,10 +544,13 @@ START_SECTION(annotateSpectra())
   TransitionTSVReader tsv_reader;
   TargetedExperiment targeted_exp;
 
-  ptr->setRTWindow(30);
-  ptr->setMZTolerance(0.1);
-  ptr->setGaussWidth(0.25);
   ptr->setUseGauss(true);
+  ptr->setGaussWidth(0.25);
+  ptr->setRTWindow(30.0);
+  ptr->setMZTolerance(0.1);
+  ptr->setPeakHeightMin(15000.0);
+  ptr->setPeakHeightMax(110000.0);
+  ptr->setFWHMThreshold(0.23);
 
   mzml.load(experiment_path, experiment);
   tsv_reader.convertTSVToTargetedExperiment(target_list_path.c_str(), FileTypes::CSV, targeted_exp);
@@ -504,112 +564,7 @@ START_SECTION(annotateSpectra())
   TEST_NOT_EQUAL(annotated_spectra.size(), 0)
   TEST_EQUAL(annotated_spectra.size(), features.size())
 
-  ofstream outfile;
-  outfile.open(
-    OPENMS_GET_TEST_DATA_PATH("SpectrumExtractor_annotateSpectra_test.html"),
-    ios::out | ios::trunc
-  );
-  if (outfile.is_open())
-  {
-    const string header = ""
-    "<!doctype html>"
-    "<html>"
-    "<head>"
-    "  <script src=\"https://cdn.plot.ly/plotly-latest.min.js\"></script>"
-    "</head>"
-    "<body>"
-    "  <div id=\"plot-here\" style=\"height: 800px\"></div>"
-    "RT window: " + to_string(ptr->getRTWindow()) + "<br>"
-    "MZ tolerance: " + to_string(ptr->getMZTolerance()) + "<br>"
-    "Gauss width: " + to_string(ptr->getGaussWidth()) + "<br>"
-    "Using Gauss filter: " + to_string(ptr->getUseGauss()) + "<br>"
-    "</body>"
-    "<script>"
-    "const data = [";
-
-    outfile << header;
-    for (UInt i=0; i<annotated_spectra.size(); ++i)
-    {
-      MSSpectrum picked_spectrum;
-      ptr->pickSpectrum(annotated_spectra[i], picked_spectrum);
-
-      outfile << "  {" << endl <<  "    x: [";
-      for (auto s : annotated_spectra[i])
-      {
-        outfile << s.getMZ() << ", ";
-      }
-      outfile << "]," << endl << "    y: [";
-      for (auto s : annotated_spectra[i])
-      {
-        outfile << s.getIntensity() << ", ";
-      }
-      outfile << "]," << endl;
-
-      string annotated_trace_ending = ""
-      "    legendgroup: '" + to_string(i) + "',"
-      "    visible: 'legendonly',"
-      "    mode: 'lines+markers',"
-      "    name: '[" + to_string(i) + "] " + picked_spectrum.getName() + "',"
-      "    type: 'scatter',"
-      "    line: {"
-      "      width: 1"
-      "    },"
-      "    marker: {"
-      "      color: 'green',"
-      "      size: 4"
-      "    }"
-      "  },";
-
-      outfile << annotated_trace_ending << endl << "{" << endl << "    x: [";
-      for (auto s : picked_spectrum)
-      {
-        outfile << s.getMZ() << ", ";
-      }
-      outfile << "]," << endl << "y: [";
-      for (auto s : picked_spectrum)
-      {
-        outfile << s.getIntensity() << ", ";
-      }
-      outfile << "]," << endl;
-      string picked_trace_ending = ""
-      "    legendgroup: '" + to_string(i) + "',"
-      "    visible: 'legendonly',"
-      "    showlegend: false,"
-      "    mode: 'markers',"
-      "    name: '[" + to_string(i) + "] " + picked_spectrum.getName() + "',"
-      "    type: 'scatter',"
-      "    marker: {"
-      "      color: 'red',"
-      "      size: 10,"
-      "      symbol: 'square-open-dot'"
-      "    }"
-      "  },";
-      outfile << picked_trace_ending << endl;
-    }
-
-    const string footer = ""
-    "];"
-    "const layout = {"
-    "  title: 'Spectrum',"
-    "  xaxis: {"
-    "    title: 'Mass-to-charge ratio (m/z)'"
-    "  },"
-    "  yaxis: {"
-    "    title: 'Intensity'"
-    "  },"
-    "  hovermode: 'closest'"
-    "};"
-    "Plotly.plot(document.getElementById('plot-here'), data, layout);"
-    "</script>"
-    "</html>";
-
-    outfile << footer;
-    outfile.close();
-  }
-  else
-  {
-    cout << "Unable to open file to write the spectrum";
-  }
+  // TODO check the values of annotated spectra, also check that metadata is present
 }
 END_SECTION
 
@@ -623,34 +578,50 @@ START_SECTION(scoreSpectra())
   mzml.load(experiment_path, experiment);
   tsv_reader.convertTSVToTargetedExperiment(target_list_path.c_str(), FileTypes::CSV, targeted_exp);
 
-  ptr->setRTWindow(30);
-  ptr->setMZTolerance(0.1);
-  ptr->setGaussWidth(0.25);
   ptr->setUseGauss(true);
+  ptr->setGaussWidth(0.25);
+  ptr->setRTWindow(30.0);
+  ptr->setMZTolerance(0.1);
+  ptr->setPeakHeightMin(15000.0);
+  ptr->setPeakHeightMax(110000.0);
+  ptr->setFWHMThreshold(0.23);
   ptr->setTICWeight(1.0);
   ptr->setFWHMWeight(1.0);
   ptr->setSNRWeight(1.0);
 
   vector<MSSpectrum> annotated_spectra;
   FeatureMap features;
-  vector<MSSpectrum> spectra = experiment.getSpectra();
+  const vector<MSSpectrum> spectra = experiment.getSpectra();
 
   ptr->annotateSpectra(spectra, targeted_exp, annotated_spectra, features);
+  TEST_EQUAL(annotated_spectra.size(), features.size())
 
   vector<MSSpectrum> picked_spectra(annotated_spectra.size());
-
   for (UInt i=0; i<annotated_spectra.size(); ++i)
   {
     ptr->pickSpectrum(annotated_spectra[i], picked_spectra[i]);
   }
 
-  ptr->setTICWeight(1.0);
-  ptr->setFWHMWeight(1.0);
-  ptr->setSNRWeight(1.0);
+  for (Int i=annotated_spectra.size()-1; i>=0; --i)
+  {
+    if (!picked_spectra[i].size())
+    {
+      annotated_spectra.erase(annotated_spectra.begin() + i);
+      picked_spectra.erase(picked_spectra.begin() + i);
+      features.erase(features.begin() + i);
+    }
+  }
+  TEST_EQUAL(annotated_spectra.size(), features.size())
+  TEST_EQUAL(picked_spectra.size(), features.size())
+
   vector<MSSpectrum> scored_spectra;
-  ptr->scoreSpectra(annotated_spectra, picked_spectra, scored_spectra, features);
+  ptr->scoreSpectra(annotated_spectra, picked_spectra, features, scored_spectra);
 
   TEST_NOT_EQUAL(scored_spectra.size(), 0)
+  TEST_EQUAL(scored_spectra.size(), annotated_spectra.size())
+  TEST_EQUAL(scored_spectra.size(), features.size())
+
+  // TODO check the values of scored spectra, also check that metadata is present
 
   // sort(scored_spectra.begin(), scored_spectra.end(), [](MSSpectrum a, MSSpectrum b)
   // {
@@ -696,14 +667,17 @@ START_SECTION(extractSpectra())
   mzml.load(experiment_path, experiment);
   tsv_reader.convertTSVToTargetedExperiment(target_list_path.c_str(), FileTypes::CSV, targeted_exp);
 
-  ptr->setRTWindow(30);
-  ptr->setMZTolerance(0.1);
-  ptr->setGaussWidth(0.25);
   ptr->setUseGauss(true);
+  ptr->setGaussWidth(0.25);
+  ptr->setRTWindow(30.0);
+  ptr->setMZTolerance(0.1);
+  ptr->setPeakHeightMin(15000.0);
+  ptr->setPeakHeightMax(110000.0);
+  ptr->setFWHMThreshold(0.23);
   ptr->setTICWeight(1.0);
   ptr->setFWHMWeight(1.0);
   ptr->setSNRWeight(1.0);
-  ptr->setMinScore(15);
+  ptr->setMinScore(15.0);
 
   vector<MSSpectrum> extracted_spectra;
   FeatureMap extracted_features;


### PR DESCRIPTION
closes #29

Added 3 new parameters: `peak_height_min_`, `peak_height_max_` and `fwhm_threshold_`.
Are the defaults assigned to these good enough?
Added the related setters and getters.

Documentation was updated.
I moved some functions' arguments around to push all input variables to the left and all output variables to the right.

TODO: improve tests on `annotateSpectra()` and `scoreSpectra()` (ie. checking the output values and if the metadata was copied as well).

EDIT:
Taking a look at the implementation of `MSSpectrum::select()`, I suspect I could replace the `for` at line 351 with a call to `select()` and selecting the peaks I desire to keep. The returned spectrum would be the one to output.
It is kind of a tradeoff between removing peaks, or copying them to a new object. Maybe the second choice is more expected or readable?