### PR TITLE
feat: Implement integratePeak()

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/PeakIntegrator.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/PeakIntegrator.h
@@ -36,8 +36,10 @@
 #define OPENMS_ANALYSIS_OPENSWATH_PEAKINTEGRATOR_H
 
 #include <OpenMS/config.h> // OPENMS_DLLAPI
+#include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/DATASTRUCTURES/DefaultParamHandler.h>
 #include <OpenMS/DATASTRUCTURES/String.h>
+#include <OpenMS/KERNEL/MSChromatogram.h>
 
 namespace OpenMS
 {
@@ -47,6 +49,15 @@ namespace OpenMS
 public:
     PeakIntegrator();
     virtual ~PeakIntegrator();
+
+    void integratePeak(
+      const MSChromatogram& chromatogram,
+      const double& left,
+      const double& right,
+      double& peak_area,
+      double& peak_height,
+      double& peak_apex_pos
+    );
 
     void setIntegrationType(const String& integration_type);
     String getIntegrationType() const;

--- a/src/openms/source/ANALYSIS/OPENSWATH/PeakIntegrator.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/PeakIntegrator.cpp
@@ -61,19 +61,17 @@ namespace OpenMS
     for (auto it=chromatogram.RTBegin(left); it!=chromatogram.RTEnd(right); ++it, ++n_points)
       ;
 
-    if (getIntegrationType() == "intensity_sum")
+    if (getIntegrationType() == "trapezoid")
     {
-      double intensity_sum = 0.0;
-      for (auto it=chromatogram.RTBegin(left); it!=chromatogram.RTEnd(right); ++it)
+      for (auto it=chromatogram.RTBegin(left); it!=chromatogram.RTEnd(right)-1; ++it)
       {
-        intensity_sum += it->getIntensity();
+        peak_area += ((it+1)->getRT() - it->getRT()) * ((it->getIntensity() + (it+1)->getIntensity()) / 2.0);
         if (peak_height < it->getIntensity())
         {
           peak_height = it->getIntensity();
           peak_apex_pos = it->getRT();
         }
       }
-      peak_area = intensity_sum / n_points;
     }
     else if (getIntegrationType() == "simpson")
     {
@@ -99,15 +97,18 @@ namespace OpenMS
     }
     else
     {
-      for (auto it=chromatogram.RTBegin(left); it!=chromatogram.RTEnd(right)-1; ++it)
+      std::cout << std::endl << "WARNING: intensity_sum method is being used." << std::endl;
+      double intensity_sum = 0.0;
+      for (auto it=chromatogram.RTBegin(left); it!=chromatogram.RTEnd(right); ++it)
       {
-        peak_area += ((it+1)->getRT() - it->getRT()) * ((it->getIntensity() + (it+1)->getIntensity()) / 2.0);
+        intensity_sum += it->getIntensity();
         if (peak_height < it->getIntensity())
         {
           peak_height = it->getIntensity();
           peak_apex_pos = it->getRT();
         }
       }
+      peak_area = intensity_sum / n_points;
     }
   }
 

--- a/src/openms/source/ANALYSIS/OPENSWATH/PeakIntegrator.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/PeakIntegrator.cpp
@@ -45,6 +45,72 @@ namespace OpenMS
 
   PeakIntegrator::~PeakIntegrator() {}
 
+  void PeakIntegrator::integratePeak(
+    const MSChromatogram& chromatogram,
+    const double& left,
+    const double& right,
+    double& peak_area,
+    double& peak_height,
+    double& peak_apex_pos
+  )
+  {
+    peak_area = 0.0;
+    peak_height = -1.0;
+    peak_apex_pos = -1.0;
+    UInt n_points = 0;
+    for (auto it=chromatogram.RTBegin(left); it!=chromatogram.RTEnd(right); ++it, ++n_points)
+      ;
+
+    if (getIntegrationType() == "intensity_sum")
+    {
+      double intensity_sum = 0.0;
+      for (auto it=chromatogram.RTBegin(left); it!=chromatogram.RTEnd(right); ++it)
+      {
+        intensity_sum += it->getIntensity();
+        if (peak_height < it->getIntensity())
+        {
+          peak_height = it->getIntensity();
+          peak_apex_pos = it->getRT();
+        }
+      }
+      peak_area = intensity_sum / n_points;
+    }
+    else if (getIntegrationType() == "simpson")
+    {
+      if (n_points < 3 || !(n_points % 2))
+      {
+        LOG_DEBUG << std::endl << "Error in integratePeak: number of points must be >=3 and odd for Simpson's rule" << std::endl;
+        return;
+      }
+      for (auto it=chromatogram.RTBegin(left); it<chromatogram.RTEnd(right)-2; it=it+2)
+      {
+        double h = (it+1)->getRT() - it->getRT();
+        double k = (it+2)->getRT() - (it+1)->getRT();
+        double y_h = it->getIntensity();
+        double y_0 = (it+1)->getIntensity();
+        double y_k = (it+2)->getIntensity();
+        peak_area += (1.0/6.0) * (h+k) * ((2.0-k/h)*y_h + (pow(h+k,2)/(h*k))*y_0 + (2.0-h/k)*y_k);
+        if (peak_height < it->getIntensity())
+        {
+          peak_height = it->getIntensity();
+          peak_apex_pos = it->getRT();
+        }
+      }
+    }
+    else
+    {
+      for (auto it=chromatogram.RTBegin(left); it!=chromatogram.RTEnd(right)-1; ++it)
+      {
+        peak_area += ((it+1)->getRT() - it->getRT()) * ((it->getIntensity() + (it+1)->getIntensity()) / 2.0);
+        if (peak_height < it->getIntensity())
+        {
+          peak_height = it->getIntensity();
+          peak_apex_pos = it->getRT();
+        }
+      }
+    }
+  }
+
   void PeakIntegrator::setIntegrationType(const String& integration_type)
   {
     integration_type_ = integration_type;

--- a/src/tests/class_tests/openms/source/PeakIntegrator_test.cpp
+++ b/src/tests/class_tests/openms/source/PeakIntegrator_test.cpp
@@ -42,6 +42,50 @@
 using namespace OpenMS;
 using namespace std;
 
+void setup_toy_chromatogram(MSChromatogram& chromatogram)
+{
+  // Toy chromatogram
+  // data is taken from raw LC-MS/MS data points acquired for L-Glutamate in RBCs
+  std::vector<double> times = {
+    2.23095,2.239716667,2.248866667,2.25765,2.266416667,
+    2.275566667,2.2847,2.293833333,2.304066667,2.315033333,2.325983333,2.336566667,
+    2.3468,2.357016667,2.367283333,2.377183333,2.387083333,2.39735,2.40725,2.4175,
+    2.4274,2.4373,2.44755,2.45745,2.4677,2.477966667,2.488216667,2.498516667,2.5084,
+    2.5183,2.5282,2.538466667,2.548366667,2.558266667,2.568516667,2.578783333,
+    2.588683333,2.59895,2.6092,2.619466667,2.630066667,2.64065,2.65125,2.662116667,
+    2.672716667,2.6833,2.6939,2.7045,2.715083333,2.725683333,2.736266667,2.746866667,
+    2.757833333,2.768416667,2.779016667,2.789616667,2.8002,2.810116667,2.820033333,
+    2.830316667,2.840216667,2.849766667,2.859316667,2.868866667,2.878783333,2.888683333,
+    2.898233333,2.907783333,2.916033333,2.924266667,2.93215,2.940383333,2.947933333,
+    2.955816667,2.964066667,2.97195,2.979833333,2.987716667,2.995616667,3.003516667,
+    3.011416667,3.01895,3.026833333,3.034366667,3.042266667,3.0498,3.05735,3.065233333,
+    3.073133333,3.080666667,3.0882,3.095733333,3.103633333,3.111533333,3.119066667,
+    3.126966667,3.134866667,3.14275,3.15065,3.15855,3.166433333,3.174333333,3.182233333,
+    3.190133333,3.198016667,3.205916667,3.213166667
+  };
+
+  std::vector<double> intensities = {
+    1447,2139,1699,755,1258,1070,944,1258,1573,1636,
+    1762,1447,1133,1321,1762,1133,1447,2391,692,1636,2957,1321,1573,1196,1258,881,
+    1384,2076,1133,1699,1384,692,1636,1133,1573,1825,1510,2391,4342,10382,17618,
+    51093,153970,368094,632114,869730,962547,966489,845055,558746,417676,270942,
+    184865,101619,59776,44863,31587,24036,20450,20324,11074,9879,10508,7928,7110,
+    6733,6481,5726,6921,6670,5537,4971,4719,4782,5097,5789,4279,5411,4530,3524,
+    2139,3335,3083,4342,4279,3083,3649,4216,4216,3964,2957,2202,2391,2643,3524,
+    2328,2202,3649,2706,3020,3335,2580,2328,2894,3146,2769,2517
+  };
+
+  chromatogram.clear(true);
+
+  for (size_t i=0; i<times.size(); ++i)
+  {
+    ChromatogramPeak peak;
+    peak.setMZ(times[i]);
+    peak.setIntensity(intensities[i]);
+    chromatogram.push_back(peak);
+  }
+}
+
 START_TEST(PeakIntegrator, "$Id$")
 
 /////////////////////////////////////////////////////////////
@@ -96,6 +140,129 @@ START_SECTION(getPeakModel())
   // TODO update this to also test the setter
   //ptr->setPeakModel("base_to_base");
   //TEST_EQUAL(ptr->getPeakModel(), "base_to_base")
+}
+END_SECTION
+
+START_SECTION(integratePeak())
+{
+  // inputs
+  MSChromatogram chromatogram;
+  setup_toy_chromatogram(chromatogram);
+  double left = 2.477966667;
+  double right = 3.01895;
+
+  // outputs
+  double peak_area;
+  double peak_height;
+  double peak_apex_pos; // (coordinates of mz or rt)
+
+  ptr->setIntegrationType("simpson");
+  ptr->integratePeak(chromatogram, left, right, peak_area, peak_height, peak_apex_pos);
+  cout << "simpson: " << endl;
+  TEST_REAL_SIMILAR(peak_area, 71720.443144994)
+  TEST_REAL_SIMILAR(peak_height, 966489.0)
+  TEST_REAL_SIMILAR(peak_apex_pos, 2.7045)
+
+  ptr->setIntegrationType("intensity_sum");
+  ptr->integratePeak(chromatogram, left, right, peak_area, peak_height, peak_apex_pos);
+  cout << "intensity_sum: " << endl;
+  TEST_REAL_SIMILAR(peak_area, 118750.49122807)
+  TEST_REAL_SIMILAR(peak_height, 966489.0)
+  TEST_REAL_SIMILAR(peak_apex_pos, 2.7045)
+
+  ptr->setIntegrationType("trapezoid");
+  ptr->integratePeak(chromatogram, left, right, peak_area, peak_height, peak_apex_pos);
+  cout << "trapezoid: " << endl;
+  TEST_REAL_SIMILAR(peak_area, 71540.2)
+  TEST_REAL_SIMILAR(peak_height, 966489.0)
+  TEST_REAL_SIMILAR(peak_apex_pos, 2.7045)
+
+  // ofstream outfile;
+  // outfile.open(
+  //   OPENMS_GET_TEST_DATA_PATH("PeakIntegrator_integratePeak_output.html"),
+  //   ios::out | ios::trunc
+  // );
+  // if (outfile.is_open())
+  // {
+  //   const string header = ""
+  //   "<!doctype html>"
+  //   "<html>"
+  //   "<head>"
+  //   "  <script src=\"https://cdn.plot.ly/plotly-latest.min.js\"></script>"
+  //   "</head>"
+  //   "<body>"
+  //   "  <div id=\"plot-here\" style=\"height: 800px\"></div>"
+  //   "left: " + to_string(left) + "<br>"
+  //   "right: " + to_string(right) + "<br>"
+  //   "area: " + to_string(peak_area) + "<br>"
+  //   "</body>"
+  //   "<script>"
+  //   "const data = [";
+  //
+  //   outfile << header;
+  //   outfile << "  {" << endl <<  "    x: [";
+  //   for (auto p : chromatogram)
+  //   {
+  //     outfile << p.getRT() << ", ";
+  //   }
+  //   outfile << "]," << endl << "    y: [";
+  //   for (auto p : chromatogram) {
+  //     outfile << p.getIntensity() << ", ";
+  //   }
+  //   outfile << "]," << endl;
+  //   string points_layout = ""
+  //   "    mode: 'markers',"
+  //   "    name: 'points',"
+  //   "    type: 'scatter',"
+  //   "    marker: {"
+  //   "      color: 'red',"
+  //   "      size: 4,"
+  //   "      symbol: 'cross'"
+  //   "    }"
+  //   "  },";
+  //
+  //   outfile << points_layout << endl << "{" << endl << "    x: [";
+  //   for (auto it=chromatogram.RTBegin(left); it!=chromatogram.RTEnd(right); ++it)
+  //   {
+  //     outfile << it->getRT() << ", ";
+  //   }
+  //   outfile << "]," << endl << "    y: [";
+  //   for (auto it=chromatogram.RTBegin(left); it!=chromatogram.RTEnd(right); ++it) {
+  //     outfile << it->getIntensity() << ", ";
+  //   }
+  //   outfile << "]," << endl;
+  //   string lines_layout = ""
+  //   "    name: 'area',"
+  //   "    type: 'scatter',"
+  //   "    mode: 'none',"
+  //   "    fill: 'tozeroy',"
+  //   "    fillcolor: 'lightskyblue'"
+  //   "  },";
+  //   outfile << lines_layout << endl;
+  //
+  //   const string footer = ""
+  //   "];"
+  //   "const layout = {"
+  //   "  title: 'Chromatogram',"
+  //   "  xaxis: {"
+  //   "    title: 'Retention time'"
+  //   "  },"
+  //   "  yaxis: {"
+  //   "    title: 'Intensity'"
+  //   "  },"
+  //   "  hovermode: 'closest'"
+  //   "};"
+  //   "Plotly.plot(document.getElementById('plot-here'), data, layout);"
+  //   "</script>"
+  //   "</html>";
+  //
+  //   outfile << footer;
+  //   outfile.close();
+  // }
+  // else
+  // {
+  //   cout << "Unable to open file to write the spectrum";
+  // }
 }
 END_SECTION
 


### PR DESCRIPTION
closes #51 

The method has 3 inputs: `left` limit, `right` limit and the `chromatogram`.
The output are `peak_area`, `peak_height` and `peak_apex_pos` which represents the position (RT).

If this looks good, I'll implement a method with the same name but which also works with `MSSpectrum` (I had forgotten about the fact I should also support that).
I guess the code will look "repeated" at that point, or is there a better way to support the two types of variables (`MSChromatogram` and `MSSpectrum`)?

edit: the method I use for the simpson's method is the one described in: _Simpson's Rule for Unequally Spaced Ordinates_ by _Shklov N._.

edit2: a problem I could see is that there is no interpolation method involved before the first intensity and after the last, meaning `peak_area` is the area between the chromatogram's first peak (after `left`) and the last one (before `right`, both intensities included). Is this fine? @dmccloskey 
ie. I'm ignoring the area between `left` and the chromatogram's first peak after `left`, and the area between the chromatogram's last peak (before `right`) and `right`.