### PR TITLE
feat: Support even number of points for Simpson rule in integratePeak()

### DIFF
--- a/src/openms/source/ANALYSIS/OPENSWATH/PeakIntegrator.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/PeakIntegrator.cpp
@@ -109,18 +109,19 @@ namespace OpenMS
     }
     else if (getIntegrationType() == "simpson")
     {
-      if (n_points < 3 || !(n_points % 2))
+      if (n_points < 3)
       {
-        LOG_DEBUG << std::endl << "Error in integratePeak: number of points must be >=3 and odd for Simpson's rule" << std::endl;
+        LOG_DEBUG << std::endl << "Error in integratePeak: number of points must be >=3 for Simpson's rule" << std::endl;
         return;
       }
-      for (auto it=chromatogram.RTBegin(left); it<chromatogram.RTEnd(right)-2; it=it+2)
+      const size_t last_pos = n_points % 2 ? 2 : 1;
+      for (auto it=chromatogram.RTBegin(left); it<chromatogram.RTEnd(right)-last_pos; it=it+2)
       {
-        double h = (it+1)->getRT() - it->getRT();
-        double k = (it+2)->getRT() - (it+1)->getRT();
-        double y_h = it->getIntensity();
-        double y_0 = (it+1)->getIntensity();
-        double y_k = (it+2)->getIntensity();
+        const double h = (it+1)->getRT() - it->getRT();
+        const double k = (it+2)->getRT() - (it+1)->getRT();
+        const double y_h = it->getIntensity();
+        const double y_0 = (it+1)->getIntensity();
+        const double y_k = (it+2)->getIntensity();
         peak_area += (1.0/6.0) * (h+k) * ((2.0-k/h)*y_h + (pow(h+k,2)/(h*k))*y_0 + (2.0-h/k)*y_k);
         if (peak_height < it->getIntensity())
         {

--- a/src/tests/class_tests/openms/source/PeakIntegrator_test.cpp
+++ b/src/tests/class_tests/openms/source/PeakIntegrator_test.cpp
@@ -198,6 +198,14 @@ START_SECTION(integratePeak())
   TEST_REAL_SIMILAR(peak_height, 966489.0)
   TEST_REAL_SIMILAR(peak_apex_pos, 2.7045)
 
+  right = 3.011416667;
+  ptr->setIntegrationType("simpson");
+  ptr->integratePeak(chromatogram, left, right, peak_area, peak_height, peak_apex_pos);
+  cout << "simpson (even number of points): " << endl;
+  TEST_REAL_SIMILAR(peak_area, 71720.443144994)
+  TEST_REAL_SIMILAR(peak_height, 966489.0)
+  TEST_REAL_SIMILAR(peak_apex_pos, 2.7045)
+
   // ofstream outfile;
   // outfile.open(
   //   OPENMS_GET_TEST_DATA_PATH("PeakIntegrator_integratePeak_output.html"),


### PR DESCRIPTION
closes #62 

This should make possible to use the Simpson rule with an even number of points.
I verify it in the tests by including one less point (comparing the test to the previous simpson test), but getting the same result as the previous test.