### PR TITLE
feat: even n of points support for simpson integration

### DIFF
--- a/src/openms/source/ANALYSIS/OPENSWATH/PeakIntegrator.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/PeakIntegrator.cpp
@@ -89,7 +89,13 @@ namespace OpenMS
     peak_apex_pos_ = -1.0;
     UInt n_points = 0;
     for (auto it=chromatogram.RTBegin(left); it!=chromatogram.RTEnd(right); ++it, ++n_points)
-      ;
+    {
+      if (peak_height_ < it->getIntensity())
+      {
+        peak_height_ = it->getIntensity();
+        peak_apex_pos_ = it->getRT();
+      }
+    }
 
     if (getIntegrationType() == "trapezoid")
     {
@@ -133,15 +139,6 @@ namespace OpenMS
         intensity_sum += it->getIntensity();
       }
       peak_area_ = intensity_sum / n_points;
-    }
-
-    for (auto it=chromatogram.RTBegin(left); it!=chromatogram.RTEnd(right); ++it)
-    {
-      if (peak_height_ < it->getIntensity())
-      {
-        peak_height_ = it->getIntensity();
-        peak_apex_pos_ = it->getRT();
-      }
     }
   }
 

--- a/src/openms/source/ANALYSIS/OPENSWATH/PeakIntegrator.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/PeakIntegrator.cpp
@@ -96,33 +96,32 @@ namespace OpenMS
       for (auto it=chromatogram.RTBegin(left); it!=chromatogram.RTEnd(right)-1; ++it)
       {
         peak_area_ += ((it+1)->getRT() - it->getRT()) * ((it->getIntensity() + (it+1)->getIntensity()) / 2.0);
-        if (peak_height_ < it->getIntensity())
-        {
-          peak_height_ = it->getIntensity();
-          peak_apex_pos_ = it->getRT();
-        }
       }
     }
     else if (getIntegrationType() == "simpson")
     {
-      if (n_points < 3 || !(n_points % 2))
+      if (n_points < 3)
       {
-        LOG_DEBUG << std::endl << "Error in integratePeak: number of points must be >=3 and odd for Simpson's rule" << std::endl;
+        LOG_DEBUG << std::endl << "Error in integratePeak: number of points must be >=3 for Simpson's rule" << std::endl;
         return;
       }
-      for (auto it=chromatogram.RTBegin(left); it<chromatogram.RTEnd(right)-2; it=it+2)
+      for (auto it=chromatogram.RTBegin(left)+1; it<chromatogram.RTEnd(right)-1; it=it+2)
       {
-        double h = (it+1)->getRT() - it->getRT();
-        double k = (it+2)->getRT() - (it+1)->getRT();
-        double y_h = it->getIntensity();
-        double y_0 = (it+1)->getIntensity();
-        double y_k = (it+2)->getIntensity();
+        const double h = it->getRT() - (it-1)->getRT();
+        const double k = (it+1)->getRT() - it->getRT();
+        const double y_h = (it-1)->getIntensity();
+        const double y_0 = it->getIntensity();
+        const double y_k = (it+1)->getIntensity();
         peak_area_ += (1.0/6.0) * (h+k) * ((2.0-k/h)*y_h + (pow(h+k,2)/(h*k))*y_0 + (2.0-h/k)*y_k);
-        if (peak_height_ < it->getIntensity())
-        {
-          peak_height_ = it->getIntensity();
-          peak_apex_pos_ = it->getRT();
-        }
+      }
+      if (!(n_points % 2) && chromatogram.RTEnd(right) != chromatogram.end()){ // if number of points is even
+        const auto it = chromatogram.RTEnd(right) - 1;
+        const double h = it->getRT() - (it-1)->getRT();
+        const double k = (it+1)->getRT() - it->getRT();
+        const double y_h = (it-1)->getIntensity();
+        const double y_0 = it->getIntensity();
+        const double y_k = (it+1)->getIntensity();
+        peak_area_ = (peak_area_ * 2.0 + (1.0/6.0) * (h+k) * ((2.0-k/h)*y_h + (pow(h+k,2)/(h*k))*y_0 + (2.0-h/k)*y_k)) / 2.0;
       }
     }
     else
@@ -132,13 +131,17 @@ namespace OpenMS
       for (auto it=chromatogram.RTBegin(left); it!=chromatogram.RTEnd(right); ++it)
       {
         intensity_sum += it->getIntensity();
-        if (peak_height_ < it->getIntensity())
-        {
-          peak_height_ = it->getIntensity();
-          peak_apex_pos_ = it->getRT();
-        }
       }
       peak_area_ = intensity_sum / n_points;
+    }
+
+    for (auto it=chromatogram.RTBegin(left); it!=chromatogram.RTEnd(right); ++it)
+    {
+      if (peak_height_ < it->getIntensity())
+      {
+        peak_height_ = it->getIntensity();
+        peak_apex_pos_ = it->getRT();
+      }
     }
   }
 

--- a/src/tests/class_tests/openms/source/PeakIntegrator_test.cpp
+++ b/src/tests/class_tests/openms/source/PeakIntegrator_test.cpp
@@ -192,6 +192,14 @@ START_SECTION(integratePeak())
   TEST_REAL_SIMILAR(ptr->getPeakArea(), 71540.2)
   TEST_REAL_SIMILAR(ptr->getPeakHeight(), 966489.0)
   TEST_REAL_SIMILAR(ptr->getPeakApexPosition(), 2.7045)
+
+  right = 3.011416667;
+  ptr->setIntegrationType("simpson");
+  ptr->integratePeak(chromatogram, left, right);
+  cout << "simpson (even number of points): " << endl;
+  TEST_REAL_SIMILAR(ptr->getPeakArea(), 71700.6099355464)
+  TEST_REAL_SIMILAR(ptr->getPeakHeight(), 966489.0)
+  TEST_REAL_SIMILAR(ptr->getPeakApexPosition(), 2.7045)
 }
 END_SECTION
 


### PR DESCRIPTION
closes #62 

This time I implemented the feature following your solution proposal (averaging the areas).

If the number of points is even, the algorithm verifies there is an additional point to the right and takes that into account when computing the peak's area (averaging the areas without and with that additional point).
What should happen in case there is no additional point to the right? (I guess we could ignore this case... it's probably unusual)

I also fixed a bug about the computation of the peak_height, when simpson method was selected. Basically, since the algorithm does +2 steps, the algorithm was skipping potential _highest_ heights. I moved the code outside the if/elses so that I make sure all points are taken into account in any case.