### PR TITLE
feat: add calculatePeakShapeMetrics and refactor it

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/PeakIntegrator.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/PeakIntegrator.h
@@ -50,7 +50,7 @@ public:
     PeakIntegrator();
     virtual ~PeakIntegrator();
 
-    double estimateBackground(
+    void estimateBackground(
       const MSChromatogram& chromatogram,
       const double& left,
       const double& right
@@ -62,9 +62,74 @@ public:
       const double& right
     );
 
+    // internal structure to represent various peak shape metrics
+    struct PeakShapeMetrics_ {
+      double width_at_5 = 0.0;
+      double width_at_10 = 0.0;
+      double width_at_50 = 0.0;
+      double start_time_at_10 = 0.0;
+      double start_time_at_5 = 0.0;
+      double start_time_at_50 = 0.0;
+      double end_time_at_10 = 0.0;
+      double end_time_at_5 = 0.0;
+      double end_time_at_50 = 0.0;
+      double total_width = 0.0;
+      /**
+        The tailing factor is a measure of peak tailing.
+        It is defined as the distance from the front slope of the peak to the back slope
+        divided by twice the distance from the center line of the peak to the front slope,
+        with all measurements made at 5% of the maximum peak height.
+        tailing_factor = Tf = W0.05/2a
+        where W0.05 is peak width at 5% max peak height
+        a = min width to peak maximum at 5% max peak height
+        b = max width to peak maximum at 5% max peak height
+        0.9 < Tf < 1.2
+        front Tf < 0.9
+        tailing Tf > 1.2
+      */
+      double tailing_factor = 0.0;
+      /**
+        The asymmetry factor is a measure of peak tailing.
+        It is defined as the distance from the center line of the peak to the back slope
+        divided by the distance from the center line of the peak to the front slope,
+        with all measurements made at 10% of the maximum peak height.
+        asymmetry_factor = As = b/a
+        where a is min width to peak maximum at 10% max peak height
+        b is max width to peak maximum at 10% max peak height
+      */
+      double asymmetry_factor = 0.0;
+      /**
+        The change in baseline divided by the height is
+        a way of comparing the influence of the change of baseline on the peak height.
+      */
+      double baseline_delta_2_height = 0.0;
+      /**
+        The slope of the baseline is a measure of slope change.
+        It is approximated as the difference in baselines between the peak start and peak end.
+      */
+      double slope_of_baseline = 0.0;
+      int points_across_baseline = 0;
+      int points_across_half_height = 0;
+    };
+
+    PeakIntegrator::PeakShapeMetrics_ calculatePeakShapeMetrics(
+      const MSChromatogram& chromatogram,
+      const double& left,
+      const double& right
+    ) const;
+
+    double findRTAtPoint(
+      MSChromatogram::ConstIterator it_begin,
+      MSChromatogram::ConstIterator it_end,
+      const double perc,
+      const bool is_start_time
+    ) const;
+
     double getPeakArea() const;
     double getPeakHeight() const;
-    double getPeakApexPosition() const;
+    double getPeakApexRT() const;
+    double getBackgroundHeight() const;
+    double getBackgroundArea() const;
 
     void setIntegrationType(const String& integration_type);
     String getIntegrationType() const;
@@ -86,11 +151,13 @@ private:
     String peak_model_; // none
     double peak_area_ = 0.0;
     double peak_height_ = -1.0;
-    double peak_apex_pos_ = -1.0;
+    double peak_apex_rt_ = -1.0;
+    double background_height_ = 0.0;
+    double background_area_ = 0.0;
 
     double simpson(
-      MSChromatogram::ConstIterator pt_begin,
-      MSChromatogram::ConstIterator pt_end
+      MSChromatogram::ConstIterator it_begin,
+      MSChromatogram::ConstIterator it_end
     ) const;
   };
 }

--- a/src/openms/source/ANALYSIS/OPENSWATH/PeakIntegrator.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/PeakIntegrator.cpp
@@ -45,7 +45,7 @@ namespace OpenMS
 
   PeakIntegrator::~PeakIntegrator() {}
 
-  double PeakIntegrator::estimateBackground(
+  void PeakIntegrator::estimateBackground(
     const MSChromatogram& chromatogram,
     const double& left,
     const double& right
@@ -55,6 +55,9 @@ namespace OpenMS
     const double int_r = (chromatogram.RTEnd(right)-1)->getIntensity();
     const double delta_int = int_r - int_l;
     const double delta_rt = (chromatogram.RTEnd(right)-1)->getRT() - chromatogram.RTBegin(left)->getRT();
+    const double rt_min = int_r <= int_l ? (chromatogram.RTEnd(right)-1)->getRT() : chromatogram.RTBegin(left)->getRT();
+    const double delta_int_apex = std::fabs(delta_int) * std::fabs(rt_min - peak_apex_rt_) / delta_rt;
+    background_height_ = std::min(int_r, int_l) + delta_int_apex;
     double background = 0.0;
     if (baseline_type_ == "base_to_base")
     {
@@ -92,7 +95,7 @@ namespace OpenMS
         background = std::min(int_r, int_l) * n_points;
       }
     }
-    return background;
+    background_area_ = background;
   }
 
   void PeakIntegrator::integratePeak(
@@ -103,14 +106,14 @@ namespace OpenMS
   {
     peak_area_ = 0.0;
     peak_height_ = -1.0;
-    peak_apex_pos_ = -1.0;
+    peak_apex_rt_ = -1.0;
     UInt n_points = 0;
     for (auto it=chromatogram.RTBegin(left); it!=chromatogram.RTEnd(right); ++it, ++n_points)
     {
       if (peak_height_ < it->getIntensity())
       {
         peak_height_ = it->getIntensity();
-        peak_apex_pos_ = it->getRT();
+        peak_apex_rt_ = it->getRT();
       }
     }
 
@@ -168,12 +171,12 @@ namespace OpenMS
   }
 
   double PeakIntegrator::simpson(
-    MSChromatogram::ConstIterator pt_begin,
-    MSChromatogram::ConstIterator pt_end
+    MSChromatogram::ConstIterator it_begin,
+    MSChromatogram::ConstIterator it_end
   ) const
   {
     double integral = 0.0;
-    for (auto it=pt_begin+1; it<pt_end-1; it=it+2)
+    for (auto it=it_begin+1; it<it_end-1; it=it+2)
     {
       const double h = it->getRT() - (it-1)->getRT();
       const double k = (it+1)->getRT() - it->getRT();
@@ -183,6 +186,95 @@ namespace OpenMS
       integral += (1.0/6.0) * (h+k) * ((2.0-k/h)*y_h + (pow(h+k,2)/(h*k))*y_0 + (2.0-h/k)*y_k);
     }
     return integral;
+  }
+
+  PeakIntegrator::PeakShapeMetrics_ PeakIntegrator::calculatePeakShapeMetrics(
+    const MSChromatogram& chromatogram,
+    const double& left,
+    const double& right
+  ) const
+  {
+    // TODO remove the three following lines
+    // peak_height_ = 965356;
+    // peak_apex_rt_ = 2.7045;
+    // background_height_ = 723.5;
+    PeakShapeMetrics_ peakShapeMetrics;
+    peakShapeMetrics.points_across_baseline = 0;
+
+    const double start_intensity = std::max(chromatogram.RTBegin(left)->getIntensity() - background_height_, 0.0);
+    const double end_intensity = std::max((chromatogram.RTEnd(right)-1)->getIntensity() - background_height_, 0.0);
+    // TODO remove the following couts
+    std::cout << std::endl << "int left: " << chromatogram.RTBegin(left)->getIntensity() << std::endl;
+    std::cout << "int right: " << (chromatogram.RTEnd(right)-1)->getIntensity() << std::endl;
+    std::cout << "bg_height: " << background_height_ << std::endl;
+    std::cout << "start_intensity: " << start_intensity << std:: endl;
+    std::cout << "end_intensity: " << end_intensity << std::endl;
+
+    MSChromatogram::ConstIterator it_rtbegin_l = chromatogram.RTBegin(left);
+    MSChromatogram::ConstIterator it_rtend_apex = chromatogram.RTEnd(peak_apex_rt_);
+    MSChromatogram::ConstIterator it_rtend_r = chromatogram.RTEnd(right);
+
+    peakShapeMetrics.start_time_at_5 = findRTAtPoint(it_rtbegin_l, it_rtend_apex, 0.05, true);
+    peakShapeMetrics.start_time_at_10 = findRTAtPoint(it_rtbegin_l, it_rtend_apex, 0.1, true);
+    peakShapeMetrics.start_time_at_50 = findRTAtPoint(it_rtbegin_l, it_rtend_apex, 0.5, true);
+    peakShapeMetrics.end_time_at_5 = findRTAtPoint(it_rtend_apex, it_rtend_r, 0.05, false);
+    peakShapeMetrics.end_time_at_10 = findRTAtPoint(it_rtend_apex, it_rtend_r, 0.1, false);
+    peakShapeMetrics.end_time_at_50 = findRTAtPoint(it_rtend_apex, it_rtend_r, 0.5, false);
+
+    for (auto it = it_rtbegin_l; it != it_rtend_r; ++it)
+    {
+      peakShapeMetrics.points_across_baseline++;
+      if (std::max(it->getIntensity() - background_height_, 0.0) >= 0.5 * peak_height_)
+      {
+        peakShapeMetrics.points_across_half_height++;
+      }
+    }
+
+    // peak widths
+    peakShapeMetrics.width_at_5 = peakShapeMetrics.end_time_at_5 - peakShapeMetrics.start_time_at_5;
+    peakShapeMetrics.width_at_10 = peakShapeMetrics.end_time_at_10 - peakShapeMetrics.start_time_at_10;
+    peakShapeMetrics.width_at_50 = peakShapeMetrics.end_time_at_50 - peakShapeMetrics.start_time_at_50;
+    peakShapeMetrics.total_width = right - left;
+    peakShapeMetrics.slope_of_baseline = end_intensity - start_intensity;
+    peakShapeMetrics.baseline_delta_2_height = peakShapeMetrics.slope_of_baseline / peak_height_;
+
+    // other
+    peakShapeMetrics.tailing_factor =
+      peakShapeMetrics.width_at_5 /
+      std::min(
+        peak_apex_rt_ - peakShapeMetrics.start_time_at_5,
+        peakShapeMetrics.end_time_at_5 - peak_apex_rt_
+      );
+
+    peakShapeMetrics.asymmetry_factor =
+      std::min(
+        peak_apex_rt_ - peakShapeMetrics.start_time_at_10,
+        peakShapeMetrics.end_time_at_10 - peak_apex_rt_
+      ) /
+      std::max(
+        peak_apex_rt_ - peakShapeMetrics.start_time_at_10,
+        peakShapeMetrics.end_time_at_10 - peak_apex_rt_
+      );
+
+    return peakShapeMetrics;
+  }
+
+  double PeakIntegrator::findRTAtPoint(
+    MSChromatogram::ConstIterator it_begin,
+    MSChromatogram::ConstIterator it_end,
+    const double perc,
+    const bool is_start_time
+  ) const
+  {
+    MSChromatogram::ConstIterator it = std::find_if(it_begin, it_end, [perc, this](ChromatogramPeak pt)
+    {
+      return pt.getIntensity() >= perc * peak_height_;
+    });
+    const double int_r = std::max(it->getIntensity() - background_height_, 0.0); //background-subtracted intensity
+    const double int_l = std::max((it-1)->getIntensity() - background_height_, 0.0); //background-subtracted intensity of the previous point
+    const double rt_r = it->getMZ();
+    const double rt_l = (it-1)->getMZ();
+    return rt_r - (int_r - int_l) * (rt_r - rt_l) / (is_start_time ? int_r - perc * peak_height_ : perc * peak_height_ - int_r);
   }
 
   double PeakIntegrator::getPeakArea() const
@@ -195,9 +287,19 @@ namespace OpenMS
     return peak_height_;
   }
 
-  double PeakIntegrator::getPeakApexPosition() const
+  double PeakIntegrator::getPeakApexRT() const
   {
-    return peak_apex_pos_;
+    return peak_apex_rt_;
+  }
+
+  double PeakIntegrator::getBackgroundHeight() const
+  {
+    return background_height_;
+  }
+
+  double PeakIntegrator::getBackgroundArea() const
+  {
+    return background_area_;
   }
 
   void PeakIntegrator::setIntegrationType(const String& integration_type)

--- a/src/tests/class_tests/openms/source/PeakIntegrator_test.cpp
+++ b/src/tests/class_tests/openms/source/PeakIntegrator_test.cpp
@@ -94,6 +94,11 @@ START_TEST(PeakIntegrator, "$Id$")
 PeakIntegrator* ptr = 0;
 PeakIntegrator* null_ptr = 0;
 
+const double left = 2.477966667;
+const double right = 3.01895;
+MSChromatogram chromatogram;
+setup_toy_chromatogram(chromatogram);
+
 START_SECTION(PeakIntegrator())
 {
   ptr = new PeakIntegrator();
@@ -145,74 +150,91 @@ END_SECTION
 
 START_SECTION(estimateBackground())
 {
-  MSChromatogram chromatogram;
-  setup_toy_chromatogram(chromatogram);
-  double left = 2.477966667;
-  double right = 3.01895;
-  double background = 0.0;
   Param params = ptr->getParameters();
 
   params.setValue("baseline_type", "base_to_base");
   params.setValue("integration_type", "intensity_sum");
   ptr->setParameters(params);
-  background = ptr->estimateBackground(chromatogram, left, right);
-  TEST_REAL_SIMILAR(background, 123446.661339019)
+  ptr->estimateBackground(chromatogram, left, right);
+  TEST_REAL_SIMILAR(ptr->getBackgroundArea(), 123446.661339019)
+  TEST_REAL_SIMILAR(ptr->getBackgroundHeight(), 16657.6971368377)
 
   params.setValue("baseline_type", "vertical_division");
   params.setValue("integration_type", "intensity_sum");
   ptr->setParameters(params);
-  background = ptr->estimateBackground(chromatogram, left, right);
-  TEST_REAL_SIMILAR(background, 50217)
+  ptr->estimateBackground(chromatogram, left, right);
+  TEST_REAL_SIMILAR(ptr->getBackgroundArea(), 50217)
+  TEST_REAL_SIMILAR(ptr->getBackgroundHeight(), 16657.6971368377)
 
   params.setValue("baseline_type", "base_to_base");
   params.setValue("integration_type", "trapezoid");
   ptr->setParameters(params);
-  background = ptr->estimateBackground(chromatogram, left, right);
-  TEST_REAL_SIMILAR(background, 1140.392865964)
+  ptr->estimateBackground(chromatogram, left, right);
+  TEST_REAL_SIMILAR(ptr->getBackgroundArea(), 1140.392865964)
+  TEST_REAL_SIMILAR(ptr->getBackgroundHeight(), 16657.6971368377)
 
   params.setValue("baseline_type", "vertical_division");
   params.setValue("integration_type", "trapezoid");
   ptr->setParameters(params);
-  background = ptr->estimateBackground(chromatogram, left, right);
-  TEST_REAL_SIMILAR(background, 476.606316373)
+  ptr->estimateBackground(chromatogram, left, right);
+  TEST_REAL_SIMILAR(ptr->getBackgroundArea(), 476.606316373)
+  TEST_REAL_SIMILAR(ptr->getBackgroundHeight(), 16657.6971368377)
 }
 END_SECTION
 
 START_SECTION(integratePeak())
 {
-  // inputs
-  MSChromatogram chromatogram;
-  setup_toy_chromatogram(chromatogram);
-  const double left = 2.477966667;
-  const double right = 3.01895;
-
   ptr->setIntegrationType("intensity_sum");
   ptr->integratePeak(chromatogram, left, right);
   cout << "intensity_sum: " << endl;
   TEST_REAL_SIMILAR(ptr->getPeakArea(), 6768778)
   TEST_REAL_SIMILAR(ptr->getPeakHeight(), 966489.0)
-  TEST_REAL_SIMILAR(ptr->getPeakApexPosition(), 2.7045)
+  TEST_REAL_SIMILAR(ptr->getPeakApexRT(), 2.7045)
 
   ptr->setIntegrationType("trapezoid");
   ptr->integratePeak(chromatogram, left, right);
   cout << "trapezoid: " << endl;
   TEST_REAL_SIMILAR(ptr->getPeakArea(), 71540.2)
   TEST_REAL_SIMILAR(ptr->getPeakHeight(), 966489.0)
-  TEST_REAL_SIMILAR(ptr->getPeakApexPosition(), 2.7045)
+  TEST_REAL_SIMILAR(ptr->getPeakApexRT(), 2.7045)
 
   ptr->setIntegrationType("simpson");
   ptr->integratePeak(chromatogram, left, right);
   cout << "simpson (odd number of points): " << endl;
   TEST_REAL_SIMILAR(ptr->getPeakArea(), 71720.443144994)
   TEST_REAL_SIMILAR(ptr->getPeakHeight(), 966489.0)
-  TEST_REAL_SIMILAR(ptr->getPeakApexPosition(), 2.7045)
+  TEST_REAL_SIMILAR(ptr->getPeakApexRT(), 2.7045)
 
   ptr->setIntegrationType("simpson");
   ptr->integratePeak(chromatogram, left, 3.011416667); // a lower value of "right" is passed, to have 1 less point
   cout << "simpson (even number of points): " << endl;
   TEST_REAL_SIMILAR(ptr->getPeakArea(), 71515.0792609335)
   TEST_REAL_SIMILAR(ptr->getPeakHeight(), 966489.0)
-  TEST_REAL_SIMILAR(ptr->getPeakApexPosition(), 2.7045)
+  TEST_REAL_SIMILAR(ptr->getPeakApexRT(), 2.7045)
+}
+END_SECTION
+
+START_SECTION(calculatePeakShapeMetrics())
+{
+  PeakIntegrator::PeakShapeMetrics_ peakShapeMetrics;
+  peakShapeMetrics = ptr->calculatePeakShapeMetrics(chromatogram, left, right);
+
+  TEST_REAL_SIMILAR(peakShapeMetrics.width_at_5, 0.27924231787346);
+  TEST_REAL_SIMILAR(peakShapeMetrics.width_at_10, 0.135162753574054);
+  TEST_REAL_SIMILAR(peakShapeMetrics.width_at_50, 0.0596533918928945);
+  TEST_REAL_SIMILAR(peakShapeMetrics.start_time_at_5, 2.47208309122377);
+  TEST_REAL_SIMILAR(peakShapeMetrics.start_time_at_10, 2.63202095937465);
+  TEST_REAL_SIMILAR(peakShapeMetrics.start_time_at_50,2.65389772440943);
+  TEST_REAL_SIMILAR(peakShapeMetrics.end_time_at_5, 2.75132540909723);
+  TEST_REAL_SIMILAR(peakShapeMetrics.end_time_at_10, 2.76718371294871);
+  TEST_REAL_SIMILAR(peakShapeMetrics.end_time_at_50,2.71355111630233);
+  TEST_REAL_SIMILAR(peakShapeMetrics.total_width, 0.540983333);
+  TEST_REAL_SIMILAR(peakShapeMetrics.tailing_factor, 5.96347844593576);
+  TEST_REAL_SIMILAR(peakShapeMetrics.asymmetry_factor, 0.864852961737272);
+  TEST_REAL_SIMILAR(peakShapeMetrics.baseline_delta_2_height, 0.002151537878);
+  TEST_REAL_SIMILAR(peakShapeMetrics.slope_of_baseline, 2077);
+  TEST_EQUAL(peakShapeMetrics.points_across_baseline, 57);
+  TEST_EQUAL(peakShapeMetrics.points_across_half_height, 6);
 }
 END_SECTION
 


### PR DESCRIPTION
closes #53 

This is how the method looks after the refactor. Should be more readable and easier to assess what the algorithm is doing.

Anyway, testing the method with your same options/data doesn't give me the same results.
The struct's members `end_time_at_5`, `end_time_at_10` and `end_time_at_50` get different values and so all the others depending on these. We could look at this results together and see if the problem is in something I'm doing/assuming or if it is in the old code. 