### PR TITLE
feat: AbsoluteQuantitationMethodFile::store()

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/QUANTITATION/AbsoluteQuantitationMethod.h
+++ b/src/openms/include/OpenMS/ANALYSIS/QUANTITATION/AbsoluteQuantitationMethod.h
@@ -28,158 +28,84 @@
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // --------------------------------------------------------------------------
-// $Maintainer: Douglas McCloskey $
-// $Authors: Douglas McCloskey $
+// $Maintainer: Douglas McCloskey, Pasquale Domenico Colaianni $
+// $Authors: Douglas McCloskey, Pasquale Domenico Colaianni $
 // --------------------------------------------------------------------------
 
 #ifndef OPENMS_ANALYSIS_QUANTITATION_ABSOLUTEQUANTITATIONMETHOD_H
 #define OPENMS_ANALYSIS_QUANTITATION_ABSOLUTEQUANTITATIONMETHOD_H
 
-#include <OpenMS/config.h>
-
-//Kernal classes
-#include <OpenMS/KERNEL/StandardTypes.h>
-#include <OpenMS/KERNEL/FeatureMap.h>
-#include <OpenMS/KERNEL/MRMFeature.h>
-
-//Analysis classes
-#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModel.h>
-
-#include <cstddef> // for size_t & ptrdiff_t
-#include <vector>
-#include <string>
+#include <OpenMS/config.h> // OPENMS_DLLAPI
+#include <OpenMS/DATASTRUCTURES/String.h>
+#include <OpenMS/DATASTRUCTURES/Param.h>
 
 namespace OpenMS
 {
-
   /**
     @brief AbsoluteQuantitationMethod is a class to hold information about the
-      quantitation method and for applying and/or generating the quantitation method.
+    quantitation method and for applying and/or generating the quantitation method.
 
-    The quantitation method describes all parameters required to define the 
-      calibration curve used for absolute quantitation by Isotope Dilution Mass Spectrometry (IDMS).
-      The quantitation method also defines the statistics of the fitted calibration curve as well
-      as the lower and upper bounds of the calibration for later Quality Control.
-      
+    The quantitation method describes all parameters required to define the
+    calibration curve used for absolute quantitation by Isotope Dilution Mass Spectrometry (IDMS).
+    The quantitation method also defines the statistics of the fitted calibration curve as well
+    as the lower and upper bounds of the calibration for later Quality Control.
   */
   class OPENMS_DLLAPI AbsoluteQuantitationMethod
   {
+public:
+    AbsoluteQuantitationMethod() = default; ///< Constructor
+    ~AbsoluteQuantitationMethod() = default; ///< Destructor
 
-public:    
-  
-  //@{
-  /// Constructor
-  AbsoluteQuantitationMethod();
+    void setComponentName(const String& component_name); ///< Component name setter
+    String getComponentName() const; ///< Component name getter
 
-  /// Destructor
-  ~AbsoluteQuantitationMethod();
-  //@}
+    void setFeatureName(const String& feature_name); ///< Feature name setter
+    String getFeatureName() const; ///< Feature name getter
 
-  /// LLOD and ULOD setter
-  void setLLOD(const double& llod);
-  void setULOD(const double& ulod);
+    void setISName(const String& IS_name); ///< IS name setter
+    String getISName() const; ///< IS_name getter
 
-  /// LLOD and ULOD getter
-  double getLLOD();
-  double getULOD();
-  
-  /// LLOQ and ULOQ setter
-  void setLLOQ(const double& lloq);
-  void setULOQ(const double& uloq);
+    void setLLOD(const double llod); ///< LLOD setter
+    double getLLOD() const; ///< LLOD getter
+    void setULOD(const double ulod); ///< ULOD setter
+    double getULOD() const; ///< ULOD getter
+    bool checkLOD(const double value) const; ///< This function checks if the value is within the limits of detection (LOD)
 
-  /// LLOQ and ULOQ getter
-  double getLLOQ();
-  double getULOQ();
+    void setLLOQ(const double lloq); ///< LLOQ setter
+    double getLLOQ() const; ///< LLOQ getter
+    void setULOQ(const double uloq); ///< ULOQ setter
+    double getULOQ() const; ///< ULOQ getter
+    bool checkLOQ(const double value) const; ///< This function checks if the value is within the limits of quantitation (LOQ)
 
-  /**
-  @brief This function checks if the value is within the
-    limits of detection (LOD)
+    void setNPoints(const Int n_points); ///< Set the number of points
+    Int getNPoints() const; ///< Get the number of points
 
-  */ 
-  bool checkLOD(const double & value);
+    void setCorrelationCoefficient(const double correlation_coefficient); ///< Set the correlation coefficient
+    double getCorrelationCoefficient() const; ///< Get the correlation coefficient
 
-  /**
-  @brief This function checks if the value is within the
-    limits of quantitation (LOQ)
+    void setConcentrationUnits(const String& concentration_units); ///< Concentration units setter
+    String getConcentrationUnits() const; ///< Concentration units getter
 
-  */ 
-  bool checkLOQ(const double & value);
+    void setTransformationModel(const String& transformation_model); ///< Transformation model setter
+    String getTransformationModel() const; ///< Transformation model getter
 
-  /// component_name, IS_name, and feature_name setter
-  void setComponentName(const String& component_name);
-  void setISName(const String& IS_name);
-  void setFeatureName(const String& feature_name);
+    void setTransformationModelParams(const Param& transformation_model_params); ///< Transformation model parameters setter
+    Param getTransformationModelParams() const; ///< Transformation model parameters getter
 
-  /// component_name, IS_name, and feature_name getter
-  String getComponentName();
-  String getISName();
-  String getFeatureName();
-  
-  /// concentration_units setter
-  void setConcentrationUnits(const String& concentration_units);
-
-  /// concentration_units getter
-  String getConcentrationUnits();
-  
-  /// transformation_model and transformation_model_params setter
-  void setTransformationModel(const String& transformation_model);
-  void setTransformationModelParams(const Param& transformation_model_params);
-
-  /// transformation_model and transformation_model_params getter
-  String getTransformationModel();
-  Param getTransformationModelParams();
-  
-  /// statistics setter
-  void setNPoints(const int& n_points);
-  void setCorrelationCoefficient(const double& correlation_coefficient);
-  
-  /// statistics getter
-  int getNPoints();
-  double getCorrelationCoefficient();
-           
 private:
-  // members
-
-  /// id of the component
-  String component_name_;
-  
-  /// name of the feature (i.e., peak_apex_int or peak_area)
-  String feature_name_;
-
-  /// lower limit of detection (LLOD) of the transition
-  double llod_;
-
-  /// lower limit of quantitation (LLOQ) of the transition
-  double lloq_;
-
-  /// upper limit of detection (LLOD) of the transition
-  double ulod_;
-
-  /// upper limit of quantitation (LLOQ) of the transition
-  double uloq_;
-
-  /// number of points used in a calibration curve
-  int n_points_;
-
-  /// the Pearson R value for the correlation coefficient of the calibration curve
-  double correlation_coefficient_;
-
-  /// the internal standard (IS) name for the transition
-  String IS_name_;
-
-  /// the known concentration of the component
-  double actual_concentration_;
-
-  /// concentration units of the component's concentration
-  String concentration_units_;
-  
-  /// transformation model
-  String transformation_model_;
-
-  /// transformation model parameters
-  Param transformation_model_params_;  
+    String component_name_; ///< id of the component
+    String feature_name_; ///< name of the feature (i.e., peak_apex_int or peak_area)
+    String IS_name_; ///< the internal standard (IS) name for the transition
+    double llod_; ///< lower limit of detection (LLOD) of the transition
+    double ulod_; ///< upper limit of detection (ULOD) of the transition
+    double lloq_; ///< lower limit of quantitation (LLOQ) of the transition
+    double uloq_; ///< upper limit of quantitation (ULOQ) of the transition
+    Int n_points_; ///< number of points used in a calibration curve
+    double correlation_coefficient_; ///< the Pearson R value for the correlation coefficient of the calibration curve
+    String concentration_units_; ///< concentration units of the component's concentration
+    String transformation_model_; ///< transformation model
+    Param transformation_model_params_; ///< transformation model parameters
   };
-
 }
-#endif // OPENMS_ANALYSIS_QUANTITATION_ABSOLUTEQUANTITATIONMETHOD_H
 
+#endif // OPENMS_ANALYSIS_QUANTITATION_ABSOLUTEQUANTITATIONMETHOD_H

--- a/src/openms/include/OpenMS/FORMAT/AbsoluteQuantitationMethodFile.h
+++ b/src/openms/include/OpenMS/FORMAT/AbsoluteQuantitationMethodFile.h
@@ -78,7 +78,7 @@ public:
       @param[in] filename The output file name.
       @param[in] aqm_list The AbsoluteQuantitationMethod data to write into the file.
     */
-    void store(const String & filename, const std::vector<AbsoluteQuantitationMethod> & aqm_list) const;
+    void store(const String & filename, const std::vector<AbsoluteQuantitationMethod> & aqm_list);
 
 protected:
     /**

--- a/src/openms/include/OpenMS/FORMAT/AbsoluteQuantitationMethodFile.h
+++ b/src/openms/include/OpenMS/FORMAT/AbsoluteQuantitationMethodFile.h
@@ -28,72 +28,86 @@
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // --------------------------------------------------------------------------
-// $Maintainer: Douglas McCloskey $
-// $Authors: Douglas McCloskey $
+// $Maintainer: Douglas McCloskey, Pasquale Domenico Colaianni $
+// $Authors: Douglas McCloskey, Pasquale Domenico Colaianni $
 // --------------------------------------------------------------------------
 
 #ifndef OPENMS_FORMAT_ABSOLUTEQUANTITATIONMETHODFILE_H
 #define OPENMS_FORMAT_ABSOLUTEQUANTITATIONMETHODFILE_H
 
-#include <OpenMS/FORMAT/CsvFile.h>
-#include <OpenMS/CONCEPT/ProgressLogger.h>
-#include <OpenMS/DATASTRUCTURES/StringListUtils.h>
+
 #include <OpenMS/ANALYSIS/QUANTITATION/AbsoluteQuantitationMethod.h>
+#include <OpenMS/FORMAT/CsvFile.h>
+#include <map>
+#include <fstream>
 
 namespace OpenMS
 {
   /**
-      @brief File adapter for AbsoluteQuantitationMethod files.
+    @brief File adapter for AbsoluteQuantitationMethod files.
 
-      loads and stores .csv or .tsv files describing an AbsoluteQuantitationMethod.
+    Loads and stores .csv or .tsv files describing an AbsoluteQuantitationMethod.
 
-      @ingroup FileIO
+    @ingroup FileIO
   */
   class OPENMS_DLLAPI AbsoluteQuantitationMethodFile :
-    private CsvFile,
-    public ProgressLogger
+    private CsvFile
   {
 public:
     ///Default constructor
-    AbsoluteQuantitationMethodFile();
+    AbsoluteQuantitationMethodFile() = default;
     ///Destructor
-    ~AbsoluteQuantitationMethodFile() override;
+    ~AbsoluteQuantitationMethodFile() = default;
 
     /**
-        @brief Loads an AbsoluteQuantitationMethod file.
+      @brief Loads an AbsoluteQuantitationMethod file.
 
-        @exception Exception::FileNotFound is thrown if the file could not be opened
-        @exception Exception::ParseError is thrown if an error occurs during parsing
+      @exception Exception::FileNotFound is thrown if the file could not be opened
+      @exception Exception::ParseError is thrown if an error occurs during parsing
+
+      @param[in] filename The input file name.
+      @param[out] aqm_list Output variable where the AbsoluteQuantitationMethod data is loaded.
     */
     void load(const String & filename, std::vector<AbsoluteQuantitationMethod> & aqm_list);
 
     /**
-        @brief Stores an AbsoluteQuantitationMethod file.
+      @brief Stores an AbsoluteQuantitationMethod file.
 
-        @exception Exception::UnableToCreateFile is thrown if the file could not be created
-    */
-    void store(const String & filename, const std::vector<AbsoluteQuantitationMethod> & aqm_list);
-    
-    /**
-        @brief Checks if a file is valid with respect to the mapping file and the controlled vocabulary.
+      @exception Exception::UnableToCreateFile is thrown if the file could not be created
 
-        @param line Header line of the .csv file.
-        @param headers A map of header strings to column positions.
-        @param params_headers A map of transformation model parameter header strings to column positions.
+      @param[in] filename The output file name.
+      @param[in] aqm_list The AbsoluteQuantitationMethod data to write into the file.
     */
+    void store(const String & filename, const std::vector<AbsoluteQuantitationMethod> & aqm_list) const;
 
 protected:
-    void parseHeader_(StringList & line, std::map<String, int> & headers,
-        std::map<String, int> & params_headers);
+    /**
+      @brief Checks if a file is valid with respect to the mapping file and the controlled vocabulary.
+
+      @param[in,out] line Header line of the .csv file.
+      @param[out] headers A map of header strings to column positions.
+      @param[out] params_headers A map of transformation model parameter header strings to column positions.
+    */
+    void parseHeader_(
+      StringList & line,
+      std::map<String, Int> & headers,
+      std::map<String, Int> & params_headers
+    ) const;
 
     /**
-        @brief parses a line into the members of AbsoluteQuantitationMethod.
+      @brief Parses a line into the members of AbsoluteQuantitationMethod.
 
-        @param line line of the .csv file.
-        @param aqm AbsoluteQuantitationMethod.
+      @param[in] line line of the .csv file.
+      @param[in] headers A map of header strings to column positions.
+      @param[in] params_headers A map of transformation model parameter header strings to column positions.
+      @param[out] aqm AbsoluteQuantitationMethod.
     */
-    void parseLine_(StringList & line, std::map<String, int> & headers, 
-        std::map<String, int> & params_headers, AbsoluteQuantitationMethod & aqm);
+    void parseLine_(
+      const StringList & line,
+      const std::map<String, Int> & headers,
+      const std::map<String, Int> & params_headers,
+      AbsoluteQuantitationMethod & aqm
+    ) const;
 
   };
 

--- a/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitationMethod.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitationMethod.cpp
@@ -158,11 +158,11 @@ namespace OpenMS
 
   bool AbsoluteQuantitationMethod::checkLOD(const double value) const
   {
-    return value >= llod_ && value <= ulod_ ? true : false; // is it bracketed or not
+    return value >= llod_ && value <= ulod_; // is it bracketed or not
   }
 
   bool AbsoluteQuantitationMethod::checkLOQ(const double value) const
   {
-    return value >= lloq_ && value <= uloq_ ? true : false; // is it bracketed or not
+    return value >= lloq_ && value <= uloq_; // is it bracketed or not
   }
 } // namespace

--- a/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitationMethod.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitationMethod.cpp
@@ -28,180 +28,141 @@
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // --------------------------------------------------------------------------
-// $Maintainer: Douglas McCloskey $
-// $Authors: Douglas McCloskey $
+// $Maintainer: Douglas McCloskey, Pasquale Domenico Colaianni $
+// $Authors: Douglas McCloskey, Pasquale Domenico Colaianni $
 // --------------------------------------------------------------------------
 
 #include <OpenMS/ANALYSIS/QUANTITATION/AbsoluteQuantitationMethod.h>
 
-//Kernal classes
-#include <OpenMS/KERNEL/StandardTypes.h>
-
-//Analysis classes
-#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationDescription.h>
-#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModel.h>
-#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelLinear.h>
-#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelBSpline.h>
-#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelInterpolated.h>
-#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelLowess.h>
-
-#include <cstddef> // for size_t & ptrdiff_t
-#include <vector>
-#include <string>
-
 namespace OpenMS
 {
-    
-  AbsoluteQuantitationMethod::AbsoluteQuantitationMethod()
-  {
-  }
-  
-  AbsoluteQuantitationMethod::~AbsoluteQuantitationMethod()
-  {
-  }
-  
-  //LOD getters and setters
-  void AbsoluteQuantitationMethod::setLLOD(const double& llod)
+  void AbsoluteQuantitationMethod::setLLOD(const double llod)
   {
     llod_ = llod;
   }
-  
-  void AbsoluteQuantitationMethod::setULOD(const double& ulod)
+
+  void AbsoluteQuantitationMethod::setULOD(const double ulod)
   {
     ulod_ = ulod;
   }
-    
-  double AbsoluteQuantitationMethod::getLLOD()
+
+  double AbsoluteQuantitationMethod::getLLOD() const
   {
     return llod_;
   }
-  
-  double AbsoluteQuantitationMethod::getULOD()
+
+  double AbsoluteQuantitationMethod::getULOD() const
   {
     return ulod_;
   }
-  
-  void AbsoluteQuantitationMethod::setLLOQ(const double& lloq)
+
+  void AbsoluteQuantitationMethod::setLLOQ(const double lloq)
   {
     lloq_ = lloq;
   }
-  
-  void AbsoluteQuantitationMethod::setULOQ(const double& uloq)
+
+  void AbsoluteQuantitationMethod::setULOQ(const double uloq)
   {
     uloq_ = uloq;
   }
-  
-  double AbsoluteQuantitationMethod::getLLOQ()
+
+  double AbsoluteQuantitationMethod::getLLOQ() const
   {
     return lloq_;
   }
-  
-  double AbsoluteQuantitationMethod::getULOQ()
+
+  double AbsoluteQuantitationMethod::getULOQ() const
   {
     return uloq_;
   }
-  
-  //Component, IS, and Feature name setters  
+
   void AbsoluteQuantitationMethod::setFeatureName(const String& feature_name)
   {
     feature_name_ = feature_name;
   }
-  
-  String AbsoluteQuantitationMethod::getFeatureName()
+
+  String AbsoluteQuantitationMethod::getFeatureName() const
   {
     return feature_name_;
   } 
-  
+
   void AbsoluteQuantitationMethod::setISName(const String& IS_name)
   {
     IS_name_ = IS_name;
   }
-  
-  String AbsoluteQuantitationMethod::getISName()
+
+  String AbsoluteQuantitationMethod::getISName() const
   {
     return IS_name_;
   }
-  
+
   void AbsoluteQuantitationMethod::setComponentName(const String& component_name)
   {
     component_name_ = component_name;
   }
-  
-  String AbsoluteQuantitationMethod::getComponentName()
+
+  String AbsoluteQuantitationMethod::getComponentName() const
   {
     return component_name_;
   }
-  
-  //Concentration unit getter and setter
+
   void AbsoluteQuantitationMethod::setConcentrationUnits(const String& concentration_units)
   {
     concentration_units_ = concentration_units;
   }
 
-  String AbsoluteQuantitationMethod::getConcentrationUnits()
+  String AbsoluteQuantitationMethod::getConcentrationUnits() const
   {
     return concentration_units_;
   }
-  
-  //Transformation model getters and setters
+
   void AbsoluteQuantitationMethod::setTransformationModel(const String& transformation_model)
   {
     transformation_model_ = transformation_model;
   }
+
   void AbsoluteQuantitationMethod::setTransformationModelParams(const Param& transformation_model_params)
   {
     transformation_model_params_ = transformation_model_params;
   }
 
-  String AbsoluteQuantitationMethod::getTransformationModel()
+  String AbsoluteQuantitationMethod::getTransformationModel() const
   {
     return transformation_model_;
   }
 
-  Param AbsoluteQuantitationMethod::getTransformationModelParams()
+  Param AbsoluteQuantitationMethod::getTransformationModelParams() const
   {
     return transformation_model_params_;
   }
-  
-  //Statistics getters and setters
-  void AbsoluteQuantitationMethod::setNPoints(const int& n_points)
+
+  void AbsoluteQuantitationMethod::setNPoints(const Int n_points)
   {
     n_points_ = n_points;
   }
-  void AbsoluteQuantitationMethod::setCorrelationCoefficient(const double& correlation_coefficient)
+
+  void AbsoluteQuantitationMethod::setCorrelationCoefficient(const double correlation_coefficient)
   {
     correlation_coefficient_ = correlation_coefficient;
   }
-  
-  int AbsoluteQuantitationMethod::getNPoints()
+
+  Int AbsoluteQuantitationMethod::getNPoints() const
   {
     return n_points_;
   }
-  double AbsoluteQuantitationMethod::getCorrelationCoefficient()
+
+  double AbsoluteQuantitationMethod::getCorrelationCoefficient() const
   {
     return correlation_coefficient_;
   }
 
-  //Non getter/setter methods
-  bool AbsoluteQuantitationMethod::checkLOD(const double & value)
+  bool AbsoluteQuantitationMethod::checkLOD(const double value) const
   {
-    bool bracketted = false;
-    if (value <= ulod_ && value >= llod_)
-    {
-      bracketted = true;
-    }
-    return bracketted;
+    return value >= llod_ && value <= ulod_ ? true : false; // is it bracketed or not
   }
 
-  bool AbsoluteQuantitationMethod::checkLOQ(const double & value)
+  bool AbsoluteQuantitationMethod::checkLOQ(const double value) const
   {
-    bool bracketted = false;
-    if (value <= uloq_ && value >= lloq_)
-    {
-      bracketted = true;
-    }
-    return bracketted;
+    return value >= lloq_ && value <= uloq_ ? true : false; // is it bracketed or not
   }
-
 } // namespace
-

--- a/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitationMethod.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitationMethod.cpp
@@ -73,7 +73,7 @@ namespace OpenMS
     
   double AbsoluteQuantitationMethod::getLLOD()
   {
-    return ulod_;
+    return llod_;
   }
   
   double AbsoluteQuantitationMethod::getULOD()

--- a/src/openms/source/FORMAT/AbsoluteQuantitationMethodFile.cpp
+++ b/src/openms/source/FORMAT/AbsoluteQuantitationMethodFile.cpp
@@ -28,27 +28,14 @@
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // --------------------------------------------------------------------------
-// $Maintainer: Mathias Walzer $
-// $Authors: Mathias Walzer $
+// $Maintainer: Douglas McCloskey, Pasquale Domenico Colaianni $
+// $Authors: Douglas McCloskey, Pasquale Domenico Colaianni $
 // --------------------------------------------------------------------------
 
-#include <OpenMS/FORMAT/CsvFile.h>
 #include <OpenMS/FORMAT/AbsoluteQuantitationMethodFile.h>
-#include <OpenMS/ANALYSIS/QUANTITATION/AbsoluteQuantitationMethod.h>
-#include <OpenMS/SYSTEM/File.h>
-#include <OpenMS/DATASTRUCTURES/StringListUtils.h>
 
 namespace OpenMS
 {
-
-  AbsoluteQuantitationMethodFile::AbsoluteQuantitationMethodFile()
-  {
-  }
-
-  AbsoluteQuantitationMethodFile::~AbsoluteQuantitationMethodFile()
-  {
-  }
-
   void AbsoluteQuantitationMethodFile::load(const String & filename, std::vector<AbsoluteQuantitationMethod> & aqm_list)
   {
     // read in the .csv file
@@ -58,8 +45,8 @@ namespace OpenMS
     CsvFile::load(filename, is, ie, first_n);
 
     // parse the file
-    std::map<String,int> headers;
-    std::map<String,int> params_headers;
+    std::map<String, Int> headers;
+    std::map<String, Int> params_headers;
     StringList line, header;
     AbsoluteQuantitationMethod aqm;
     for (size_t i = 0; i < CsvFile::rowCount(); ++i)
@@ -71,15 +58,18 @@ namespace OpenMS
       }
       else
       {
-        CsvFile::getRow(i, line); 
-        parseLine_(line, headers, params_headers, aqm);    
-        aqm_list.push_back(aqm);  
-      }    
+        CsvFile::getRow(i, line);
+        parseLine_(line, headers, params_headers, aqm);
+        aqm_list.push_back(aqm);
+      }
     }
   }
 
-  void AbsoluteQuantitationMethodFile::parseHeader_(StringList & line, std::map<String, int> & headers,
-    std::map<String, int> & params_headers)
+  void AbsoluteQuantitationMethodFile::parseHeader_(
+    StringList & line,
+    std::map<String, Int> & headers,
+    std::map<String, Int> & params_headers
+  ) const
   {    
     // default header column positions
     headers["IS_name"] = -1;
@@ -111,84 +101,88 @@ namespace OpenMS
     }
   }
 
-  void AbsoluteQuantitationMethodFile::parseLine_(StringList & line, std::map<String,int> & headers, 
-    std::map<String,int> & params_headers, AbsoluteQuantitationMethod & aqm)
+  void AbsoluteQuantitationMethodFile::parseLine_(
+    const StringList & line,
+    const std::map<String, Int> & headers,
+    const std::map<String, Int> & params_headers,
+    AbsoluteQuantitationMethod & aqm
+  ) const
   {
     // component, IS, and feature names
     String component_name = "";
-    if (headers["component_name"] != -1)
+    if (headers.at("component_name") != -1)
     {
-      component_name = line[headers["component_name"]];
+      component_name = line[headers.at("component_name")];
     }
     aqm.setComponentName(component_name);
     String feature_name = "";
-    if (headers["feature_name"] != -1)
+    if (headers.at("feature_name") != -1)
     {
-      feature_name = line[headers["feature_name"]];
+      feature_name = line[headers.at("feature_name")];
     }
     aqm.setFeatureName(feature_name);
     String IS_name = "";
-    if (headers["IS_name"] != -1)
+    if (headers.at("IS_name") != -1)
     {
-      IS_name = line[headers["IS_name"]];
+      IS_name = line[headers.at("IS_name")];
     }
     aqm.setISName(IS_name);
 
     // LODs
     double llod = 0.0;
-    if (headers["llod"] != -1)
+    if (headers.at("llod") != -1)
     {
-      llod = (line[headers["llod"]].empty()) ? 0.0 : std::stod(line[headers["llod"]]);
+      llod = (line[headers.at("llod")].empty()) ? 0.0 : std::stod(line[headers.at("llod")]);
     }
     aqm.setLLOD(llod);
     double ulod = 0.0;
-    if (headers["ulod"] != -1)
+    if (headers.at("ulod") != -1)
     {
-      ulod = (line[headers["ulod"]].empty()) ? 0.0 : std::stod(line[headers["ulod"]]);
+      ulod = (line[headers.at("ulod")].empty()) ? 0.0 : std::stod(line[headers.at("ulod")]);
     }
     aqm.setULOD(ulod);
 
     // LOQs
     double lloq = 0.0;
-    if (headers["lloq"] != -1)
+    if (headers.at("lloq") != -1)
     {
-      lloq = (line[headers["lloq"]].empty()) ? 0.0 : std::stod(line[headers["lloq"]]);
+      lloq = (line[headers.at("lloq")].empty()) ? 0.0 : std::stod(line[headers.at("lloq")]);
     }
     aqm.setLLOQ(lloq);
     double uloq = 0.0;
-    if (headers["uloq"] != -1)
+    if (headers.at("uloq") != -1)
     {
-      uloq = (line[headers["uloq"]].empty()) ? 0.0 : std::stod(line[headers["uloq"]]);
+      uloq = (line[headers.at("uloq")].empty()) ? 0.0 : std::stod(line[headers.at("uloq")]);
     }
     aqm.setULOQ(uloq);
 
     // concentration units
     String concentration_units = "";
-    if (headers["concentration_units"] != -1)
+    if (headers.at("concentration_units") != -1)
     {
-      concentration_units = line[headers["concentration_units"]];
+      concentration_units = line[headers.at("concentration_units")];
     }
     aqm.setConcentrationUnits(concentration_units);
 
     // statistics
-    int n_points = 0;
-    if (headers["n_points"] != -1)
+    Int n_points = 0;
+    if (headers.at("n_points") != -1)
     {
-      n_points = (line[headers["n_points"]].empty()) ? 0.0 : std::stoi(line[headers["n_points"]]);
+      n_points = (line[headers.at("n_points")].empty()) ? 0.0 : std::stoi(line[headers.at("n_points")]);
     }
     aqm.setNPoints(n_points);
     double correlation_coefficient = 0.0;
-    if (headers["correlation_coefficient"] != -1)
+    if (headers.at("correlation_coefficient") != -1)
     {
-      correlation_coefficient = (line[headers["correlation_coefficient"]].empty()) ? 0.0 : std::stod(line[headers["correlation_coefficient"]]);
+      correlation_coefficient = (line[headers.at("correlation_coefficient")].empty()) ? 0.0 : std::stod(line[headers.at("correlation_coefficient")]);
     }
     aqm.setCorrelationCoefficient(correlation_coefficient);
 
     // transformation model
     String transformation_model = "";
-    if (headers["transformation_model"] != -1)
+    if (headers.at("transformation_model") != -1)
     {
-      transformation_model = line[headers["transformation_model"]];
+      transformation_model = line[headers.at("transformation_model")];
     }
     Param transformation_model_params;
     for (auto const& kv : params_headers)
@@ -216,9 +210,58 @@ namespace OpenMS
     aqm.setTransformationModelParams(transformation_model_params);
   }
 
-  // void AbsoluteQuantitationMethodFile::store(const String & filename, const std::vector<AbsoluteQuantitationMethod> & aqm_list)
-  // {
-  //   // TODO: pending fix to CsvFile::fstore()
-  // }
-
+  void AbsoluteQuantitationMethodFile::store(
+    const String& filename,
+    const std::vector<AbsoluteQuantitationMethod>& aqm_list
+  ) const
+  {
+    std::ofstream ofs(filename);
+    if (!ofs.is_open())
+    {
+      throw Exception::UnableToCreateFile(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename);
+    }
+    std::vector<String> tm_params_names;
+    if (aqm_list.size())
+    {
+      const Param tm_params = aqm_list[0].getTransformationModelParams();
+      for (const Param::ParamEntry& tm_param : tm_params)
+      {
+        if (std::find(tm_params_names.begin(), tm_params_names.end(), tm_param.name) == tm_params_names.end())
+        {
+          tm_params_names.insert(tm_params_names.begin(), tm_param.name);
+        }
+      }
+    }
+    // Write headers to stream
+    // Assuming the following headers are always present
+    ofs << "IS_name,component_name,feature_name,concentration_units,llod,ulod,lloq,uloq,correlation_coefficient,n_points,transformation_model";
+    // However, the following headers could be absent
+    for (const String tm_param_header : tm_params_names)
+    {
+      ofs << "," << "transformation_model_param_" << tm_param_header;
+    }
+    ofs << std::endl;
+    // Write raw data
+    for (const AbsoluteQuantitationMethod& aqm : aqm_list)
+    {
+      ofs << aqm.getISName() << ",";
+      ofs << aqm.getComponentName() << ",";
+      ofs << aqm.getFeatureName() << ",";
+      ofs << aqm.getConcentrationUnits() << ",";
+      ofs << aqm.getLLOD() << ",";
+      ofs << aqm.getULOD() << ",";
+      ofs << aqm.getLLOQ() << ",";
+      ofs << aqm.getULOQ() << ",";
+      ofs << aqm.getCorrelationCoefficient() << ",";
+      ofs << aqm.getNPoints() << ",";
+      ofs << aqm.getTransformationModel();
+      const Param tm_params = aqm.getTransformationModelParams();
+      for (const String tm_param : tm_params_names)
+      {
+        ofs << "," << tm_params.getValue(tm_param);
+      }
+      ofs << std::endl;
+    }
+    ofs.close();
+  }
 } // namespace OpenMS

--- a/src/pyOpenMS/pxds/AbsoluteQuantitationMethod.pxd
+++ b/src/pyOpenMS/pxds/AbsoluteQuantitationMethod.pxd
@@ -23,23 +23,22 @@ cdef extern from "<OpenMS/ANALYSIS/QUANTITATION/AbsoluteQuantitationMethod.h>" n
         void checkLOD(double value) nogil except +
         void checkLOQ(double value) nogil except +
         
-        void setComponentName(String component_name) nogil except +
-        void setISName(String IS_name) nogil except +
-        void setFeatureName(String feature_name) nogil except +
+        void setComponentName(String& component_name) nogil except +
+        void setISName(String& IS_name) nogil except +
+        void setFeatureName(String& feature_name) nogil except +
         String getComponentName() nogil except +
         String getISName() nogil except +
         String getFeatureName() nogil except +
 
-        void setConcentrationUnits(String concentration_units) nogil except +
+        void setConcentrationUnits(String& concentration_units) nogil except +
         String getConcentrationUnits() nogil except +
 
-        void setTransformationModel(String transformation_model) nogil except +
+        void setTransformationModel(String& transformation_model) nogil except +
         void setTransformationModelParams(Param transformation_model_param) nogil except +
         String getTransformationModel() nogil except +
         Param getTransformationModelParams() nogil except +
 
-        void setNPoints(int n_points) nogil except +
+        void setNPoints(Int n_points) nogil except +
         void setCorrelationCoefficient(double correlation_coefficient) nogil except +
-        int getNPoints() nogil except +
+        Int getNPoints() nogil except +
         double getCorrelationCoefficient() nogil except +
-

--- a/src/pyOpenMS/pxds/AbsoluteQuantitationMethodFile.pxd
+++ b/src/pyOpenMS/pxds/AbsoluteQuantitationMethodFile.pxd
@@ -1,5 +1,4 @@
 from Types cimport *
-from Param cimport *
 from AbsoluteQuantitationMethod cimport *
 
 cdef extern from "<OpenMS/FORMAT/AbsoluteQuantitationMethodFile.h>" namespace "OpenMS":
@@ -9,5 +8,5 @@ cdef extern from "<OpenMS/FORMAT/AbsoluteQuantitationMethodFile.h>" namespace "O
         AbsoluteQuantitationMethodFile()  nogil except +
         AbsoluteQuantitationMethodFile(AbsoluteQuantitationMethodFile)  nogil except + #wrap-ignore
 
-        void load(String filename, libcpp_vector[ AbsoluteQuantitationMethod ]& aqm_list) nogil except +
-
+        void load(const String& filename, libcpp_vector[ AbsoluteQuantitationMethod ]& aqm_list) nogil except +
+        void store(const String& filename, libcpp_vector[ AbsoluteQuantitationMethod ]& aqm_list) nogil except +

--- a/src/tests/class_tests/openms/source/AbsoluteQuantitationMethodFile_test.cpp
+++ b/src/tests/class_tests/openms/source/AbsoluteQuantitationMethodFile_test.cpp
@@ -28,8 +28,8 @@
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // --------------------------------------------------------------------------
-// $Maintainer: Douglas McCloskey $
-// $Authors: Douglas McCloskey $
+// $Maintainer: Douglas McCloskey, Pasquale Domenico Colaianni $
+// $Authors: Douglas McCloskey, Pasquale Domenico Colaianni $
 // --------------------------------------------------------------------------
 //
 
@@ -259,6 +259,34 @@ START_SECTION((void load(const String & filename, std::vector<AbsoluteQuantitati
   TEST_REAL_SIMILAR(transformation_model_params.getValue("intercept"),2.0);
   transformation_model_params.clear();
 
+END_SECTION
+
+START_SECTION(void store(const String & filename, const std::vector<AbsoluteQuantitationMethod> & aqm_list) const)
+  AbsoluteQuantitationMethodFile aqmf;
+  vector<AbsoluteQuantitationMethod> aqm_list1, aqm_list2;
+  aqmf.load(OPENMS_GET_TEST_DATA_PATH("AbsoluteQuantitationMethodFile_1.csv"), aqm_list1);
+  aqmf.store(OPENMS_GET_TEST_DATA_PATH("AbsoluteQuantitationMethodFile_2.csv"), aqm_list1);
+  aqmf.load(OPENMS_GET_TEST_DATA_PATH("AbsoluteQuantitationMethodFile_1.csv"), aqm_list2);
+  TEST_EQUAL(aqm_list1.size(), aqm_list2.size())
+  for (Size i = 0; i < aqm_list1.size(); ++i)
+  {
+    TEST_EQUAL(aqm_list1[i].getISName(), aqm_list2[i].getISName())
+    TEST_EQUAL(aqm_list1[i].getComponentName(), aqm_list2[i].getComponentName())
+    TEST_EQUAL(aqm_list1[i].getFeatureName(), aqm_list2[i].getFeatureName())
+    TEST_EQUAL(aqm_list1[i].getConcentrationUnits(), aqm_list2[i].getConcentrationUnits())
+    TEST_REAL_SIMILAR(aqm_list1[i].getLLOD(), aqm_list2[i].getLLOD())
+    TEST_REAL_SIMILAR(aqm_list1[i].getULOD(), aqm_list2[i].getULOD())
+    TEST_REAL_SIMILAR(aqm_list1[i].getLLOQ(), aqm_list2[i].getLLOQ())
+    TEST_REAL_SIMILAR(aqm_list1[i].getULOQ(), aqm_list2[i].getULOQ())
+    TEST_REAL_SIMILAR(aqm_list1[i].getCorrelationCoefficient(), aqm_list2[i].getCorrelationCoefficient())
+    TEST_EQUAL(aqm_list1[i].getNPoints(), aqm_list2[i].getNPoints())
+    TEST_EQUAL(aqm_list1[i].getTransformationModel(), aqm_list2[i].getTransformationModel())
+    const Param& tm_params1 = aqm_list1[i].getTransformationModelParams();
+    const Param& tm_params2 = aqm_list2[i].getTransformationModelParams();
+    TEST_EQUAL(tm_params1.size(), tm_params2.size())
+    TEST_REAL_SIMILAR(tm_params1.getValue("slope"), tm_params2.getValue("slope"))
+    TEST_REAL_SIMILAR(tm_params1.getValue("intercept"), tm_params2.getValue("intercept"))
+  }
 END_SECTION
 
 /////////////////////////////////////////////////////////////

--- a/src/tests/class_tests/openms/source/AbsoluteQuantitationMethod_test.cpp
+++ b/src/tests/class_tests/openms/source/AbsoluteQuantitationMethod_test.cpp
@@ -28,8 +28,8 @@
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // --------------------------------------------------------------------------
-// $Maintainer: Douglas McCloskey $
-// $Authors: Douglas McCloskey $
+// $Maintainer: Douglas McCloskey, Pasquale Domenico Colaianni $
+// $Authors: Douglas McCloskey, Pasquale Domenico Colaianni $
 // --------------------------------------------------------------------------
 //
 
@@ -39,14 +39,6 @@
 ///////////////////////////
 
 #include <OpenMS/ANALYSIS/QUANTITATION/AbsoluteQuantitationMethod.h>
-
-//Analysis classes
-#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationDescription.h>
-#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModel.h>
-#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelLinear.h>
-#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelBSpline.h>
-#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelInterpolated.h>
-#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelLowess.h>
 
 using namespace OpenMS;
 using namespace std;
@@ -59,47 +51,83 @@ START_TEST(AbsoluteQuantitationMethod, "$Id$")
 
 AbsoluteQuantitationMethod* ptr = nullptr;
 AbsoluteQuantitationMethod* nullPointer = nullptr;
-START_SECTION((AbsoluteQuantitationMethod()))
-	ptr = new AbsoluteQuantitationMethod();
-	TEST_NOT_EQUAL(ptr, nullPointer);
+
+START_SECTION(AbsoluteQuantitationMethod())
+{
+  ptr = new AbsoluteQuantitationMethod();
+  TEST_NOT_EQUAL(ptr, nullPointer);
+}
 END_SECTION
 
-START_SECTION((~AbsoluteQuantitationMethod()))
-	delete ptr;
+START_SECTION(~AbsoluteQuantitationMethod())
+{
+  delete ptr;
+}
 END_SECTION
 
-START_SECTION((bool checkLOD(const double & value)))
-
+START_SECTION(all setters and getters)
+{
   AbsoluteQuantitationMethod aqm;
-  double value = 2.0;
 
-  // tests
+  aqm.setComponentName("component");
+  aqm.setFeatureName("feature");
+  aqm.setISName("IS");
+  aqm.setLLOD(1.2);
+  aqm.setULOD(3.4);
+  aqm.setLLOQ(5.6);
+  aqm.setULOQ(7.8);
+  aqm.setNPoints(9);
+  aqm.setCorrelationCoefficient(0.44);
+  aqm.setConcentrationUnits("uM");
+  aqm.setTransformationModel("TransformationModelLinear");
+  Param params1;
+  params1.setValue("slope", 1);
+  aqm.setTransformationModelParams(params1);
+
+  TEST_EQUAL(aqm.getComponentName(), "component")
+  TEST_EQUAL(aqm.getFeatureName(), "feature")
+  TEST_EQUAL(aqm.getISName(), "IS")
+  TEST_REAL_SIMILAR(aqm.getLLOD(), 1.2)
+  TEST_REAL_SIMILAR(aqm.getULOD(), 3.4)
+  TEST_REAL_SIMILAR(aqm.getLLOQ(), 5.6)
+  TEST_REAL_SIMILAR(aqm.getULOQ(), 7.8)
+  TEST_EQUAL(aqm.getNPoints(), 9)
+  TEST_REAL_SIMILAR(aqm.getCorrelationCoefficient(), 0.44)
+  TEST_EQUAL(aqm.getConcentrationUnits(), "uM")
+  TEST_EQUAL(aqm.getTransformationModel(), "TransformationModelLinear")
+  Param params2 = aqm.getTransformationModelParams();
+  TEST_EQUAL(params2.getValue("slope"), 1)
+}
+END_SECTION
+
+START_SECTION(bool checkLOD(const double value) const)
+{
+  AbsoluteQuantitationMethod aqm;
+  const double value = 2.0;
   aqm.setLLOD(0.0);
   aqm.setULOD(4.0);
-  TEST_EQUAL(aqm.checkLOD(value),true);
-  aqm.setLLOD(0.0);
+  TEST_EQUAL(aqm.checkLOD(value), true);
   aqm.setULOD(1.0);
-  TEST_EQUAL(aqm.checkLOD(value),false);
+  TEST_EQUAL(aqm.checkLOD(value), false);
   aqm.setLLOD(3.0);
   aqm.setULOD(4.0);
-  TEST_EQUAL(aqm.checkLOD(value),false);
+  TEST_EQUAL(aqm.checkLOD(value), false);
+}
 END_SECTION
 
-START_SECTION((bool checkLOQ(const double & value)))
-
+START_SECTION(bool checkLOQ(const double value) const)
+{
   AbsoluteQuantitationMethod aqm;
-  double value = 2.0;
-
-  // tests
+  const double value = 2.0;
   aqm.setLLOQ(0.0);
   aqm.setULOQ(4.0);
-  TEST_EQUAL(aqm.checkLOQ(value),true);
-  aqm.setLLOQ(0.0);
+  TEST_EQUAL(aqm.checkLOQ(value), true);
   aqm.setULOQ(1.0);
-  TEST_EQUAL(aqm.checkLOQ(value),false);
+  TEST_EQUAL(aqm.checkLOQ(value), false);
   aqm.setLLOQ(3.0);
   aqm.setULOQ(4.0);
-  TEST_EQUAL(aqm.checkLOQ(value),false);
+  TEST_EQUAL(aqm.checkLOQ(value), false);
+}
 END_SECTION
 
 /////////////////////////////////////////////////////////////


### PR DESCRIPTION
implementation proposal

the PR also contains my modification from another branch (the one which fixes the AQM class), the only interesting thing here is the `store()` method.

here: https://github.com/biosustain/OpenMS/pull/99/files#diff-de82869c936b9970c20ccdc4f9d9bd61R213

the modification on how the map is used (eg. using `.at()`) in `load()` were necessary to enforce `const` correctness (due to changes in AQM class from the other branch).