### PR TITLE
feat: Implement findWidestPeakIndices()

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMTransitionGroupPicker.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMTransitionGroupPicker.h
@@ -165,7 +165,16 @@ public:
       while (true)
       {
         chr_idx = -1; peak_idx = -1;
-        findLargestPeak(picked_chroms_, chr_idx, peak_idx);
+
+        if (boundary_selection_method_ == "largest")
+        {
+          findLargestPeak(picked_chroms_, chr_idx, peak_idx);
+        }
+        else if (boundary_selection_method_ == "widest")
+        {
+          findWidestPeakIndices(picked_chroms_, chr_idx, peak_idx);
+        }
+
         if (chr_idx == -1 && peak_idx == -1) break;
 
         // Compute a feature from the individual chromatograms and add non-zero features
@@ -549,6 +558,16 @@ public:
     /// Find largest peak in a vector of chromatograms
     void findLargestPeak(std::vector<MSChromatogram >& picked_chroms, int& chr_idx, int& peak_idx);
 
+    /**
+      @brief Given a vector of chromatograms, find the indices of the chromatogram
+      containing the widest peak and of the position of highest intensity.
+
+      @param[in] picked_chroms The vector of chromatograms
+      @param[in,out] chrom_idx The index of the chromatogram containing the widest peak
+      @param[in,out] point_idx The index of the point with highest intensity
+    */
+    void findWidestPeakIndices(const std::vector<MSChromatogram>& picked_chroms, Int& chrom_idx, Int& point_idx) const;
+
 protected:
 
     /// Synchronize members with param class
@@ -923,6 +942,13 @@ protected:
     double min_peak_width_;
     double recalculate_peaks_max_z_;
     double resample_boundary_;
+
+    /**
+      @brief Which method to use for selecting peaks' boundaries
+
+      Valid values are: "largest", "widest"
+    */
+    String boundary_selection_method_;
 
     PeakPickerMRM picker_;
     PeakIntegrator pi_;


### PR DESCRIPTION
This should give you the possibility to select `best_left` and `best_right` according to the widest peak instead of the "tallest" (or largest, as is used to say within the code).

Just pass the parameter `boundary_selection_method` set to `"widest"`.

Selection of "per peak" boundaries is WIP.

If this already looks good to you, I will propose it to OpenMS and then open another PR for the "per peak" feature.