### PR TITLE
feat: Separate component and component groups files loading

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureQC.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureQC.h
@@ -114,6 +114,19 @@ public:
       /// name of the component group
       String component_group_name;
 
+      /// retention time lower bound
+      double retention_time_l;
+      /// retention time upper bound
+      double retention_time_u;
+      /// intensity lower bound
+      double intensity_l;
+      /// intensity upper bound
+      double intensity_u;
+      /// overall quality lower bound
+      double overall_quality_l;
+      /// overall quality upper bound
+      double overall_quality_u;
+
       // number of transitions and labels
       /// number of heavy ion lower bound
       int n_heavy_l;
@@ -136,6 +149,7 @@ public:
       double ion_ratio_l;
       double ion_ratio_u;
       String ion_ratio_feature_name;
+      std::map<String,std::pair<double,double>> meta_value_qc;
 
     };
 

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureQC.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureQC.h
@@ -129,19 +129,19 @@ public:
 
       // number of transitions and labels
       /// number of heavy ion lower bound
-      int n_heavy_l;
+      Int n_heavy_l;
       /// number of heavy ion upper bound
-      int n_heavy_u;
-      int n_light_l;
-      int n_light_u;
-      int n_detecting_l;
-      int n_detecting_u;
-      int n_quantifying_l;
-      int n_quantifying_u;
-      int n_identifying_l;
-      int n_identifying_u;
-      int n_transitions_l;
-      int n_transitions_u;
+      Int n_heavy_u;
+      Int n_light_l;
+      Int n_light_u;
+      Int n_detecting_l;
+      Int n_detecting_u;
+      Int n_quantifying_l;
+      Int n_quantifying_u;
+      Int n_identifying_l;
+      Int n_identifying_u;
+      Int n_transitions_l;
+      Int n_transitions_u;
 
       // Ion Ratio QCs
       String ion_ratio_pair_name_1;
@@ -183,7 +183,7 @@ public:
     /// list of all component group QCs
     std::vector<ComponentGroupQCs> component_group_qcs;
     /// list of all component group pair QCs
-    std::vector<ComponentGroupQCs> component_group_pair_qcs;
+    std::vector<ComponentGroupPairQCs> component_group_pair_qcs;
   };
 }
 

--- a/src/openms/include/OpenMS/FORMAT/MRMFeatureQCFile.h
+++ b/src/openms/include/OpenMS/FORMAT/MRMFeatureQCFile.h
@@ -80,19 +80,46 @@ public:
 
 
 protected:
+  /**
+    @brief Save values from a line to a `ComponentQCs`.
 
+    @param[in] line A line containing the values from a row in the input file
+    @param[in] headers A mapping from headers names to position indices
+    @param[out] c_qcs The ouptput will be saved in a new element of this vector
+  */
   void pushValuesFromLine_(
     const StringList& line,
     const std::map<String, Size>& headers,
     std::vector<MRMFeatureQC::ComponentQCs>& c_qcs
   ) const;
 
+  /**
+    @brief Save values from a line to a `ComponentGroupQCs`.
+
+    @param[in] line A line containing the values from a row in the input file
+    @param[in] headers A mapping from headers names to position indices
+    @param[out] cg_qcs The ouptput will be saved in a new element of this vector
+  */
   void pushValuesFromLine_(
     const StringList& line,
     const std::map<String, Size>& headers,
     std::vector<MRMFeatureQC::ComponentGroupQCs>& cg_qcs
   ) const;
 
+  /**
+    @brief Set one of the values in a pair
+
+    The method is given in input a map from Strings to pairs.
+    Assuming the key is present within the map, its mapped value will be updated
+    with the given `value`, in the correct `boundary` position.
+    If the key is not found, a new pair will be created and both its values set
+    (in this case, a default value of 0.0 is given to the other pair's element).
+
+    @param[in] key The metavalue name
+    @param[in] value The mapped pair
+    @param[in] boundary "l" for lower or "u" for upper bound
+    @param[out] meta_values_qc The map containing the metavalues and pairs
+  */
   void setPairValue_(
     const String& key,
     const String& value,

--- a/src/openms/include/OpenMS/FORMAT/MRMFeatureQCFile.h
+++ b/src/openms/include/OpenMS/FORMAT/MRMFeatureQCFile.h
@@ -83,6 +83,8 @@ protected:
   /**
     @brief Save values from a line to a `ComponentQCs`.
 
+    @note Lines missing the `component_name` value will be skipped.
+
     @param[in] line A line containing the values from a row in the input file
     @param[in] headers A mapping from headers names to position indices
     @param[out] c_qcs The ouptput will be saved in a new element of this vector
@@ -95,6 +97,8 @@ protected:
 
   /**
     @brief Save values from a line to a `ComponentGroupQCs`.
+
+    @note Lines missing the `component_group_name` value will be skipped.
 
     @param[in] line A line containing the values from a row in the input file
     @param[in] headers A mapping from headers names to position indices
@@ -117,7 +121,7 @@ protected:
 
     @param[in] key The metavalue name
     @param[in] value The mapped pair
-    @param[in] boundary "l" for lower or "u" for upper bound
+    @param[in] boundary "l" for lower bound or "u" for upper bound
     @param[out] meta_values_qc The map containing the metavalues and pairs
   */
   void setPairValue_(
@@ -127,6 +131,20 @@ protected:
     std::map<String, std::pair<double,double>>& meta_values_qc
   ) const;
 
+  /**
+    @brief Extracts a column's value from a line.
+
+    The method looks for the value found within `line[headers[header]]`.
+    If the information is present and its value is valid, it will be converted
+    to `Int` and returned.
+    Otherwise, `default_value` (provided by the user) is returned.
+
+    @param[in] headers The mapping from columns' name to positions' indices
+    @param[in] line A list of strings containinig a single row's values
+    @param[in] header The desired value's column name
+    @param[in] default_value A default value to return in case the information is not found or invalid
+    @return The found information (if found and valid) converted to `Int`. Otherwise `default_value`.
+  */
   Int getCastValue_(
     const std::map<String, Size>& headers,
     const StringList& line,
@@ -134,6 +152,20 @@ protected:
     const Int default_value
   ) const;
 
+  /**
+    @brief Extracts a column's value from a line.
+
+    The method looks for the value found within `line[headers[header]]`.
+    If the information is present and its value is valid, it will be converted
+    to `double` and returned.
+    Otherwise, `default_value` (provided by the user) is returned.
+
+    @param[in] headers The mapping from columns' name to positions' indices
+    @param[in] line A list of strings containinig a single row's values
+    @param[in] header The desired value's column name
+    @param[in] default_value A default value to return in case the information is not found or invalid
+    @return The found information (if found and valid) converted to `double`. Otherwise `default_value`.
+  */
   double getCastValue_(
     const std::map<String, Size>& headers,
     const StringList& line,
@@ -141,6 +173,20 @@ protected:
     const double default_value
   ) const;
 
+  /**
+    @brief Extracts a column's value from a line.
+
+    The method looks for the value found within `line[headers[header]]`.
+    If the information is present and its value is valid, it will be converted
+    to `String` and returned.
+    Otherwise, `default_value` (provided by the user) is returned.
+
+    @param[in] headers The mapping from columns' name to positions' indices
+    @param[in] line A list of strings containinig a single row's values
+    @param[in] header The desired value's column name
+    @param[in] default_value A default value to return in case the information is not found or invalid
+    @return The found information (if found and valid) converted to `String`. Otherwise `default_value`.
+  */
   String getCastValue_(
     const std::map<String, Size>& headers,
     const StringList& line,

--- a/src/openms/include/OpenMS/FORMAT/MRMFeatureQCFile.h
+++ b/src/openms/include/OpenMS/FORMAT/MRMFeatureQCFile.h
@@ -64,8 +64,12 @@ public:
 
     @exception Exception::FileNotFound is thrown if the file could not be opened
     @exception Exception::ParseError is thrown if an error occurs during parsing
+
+    @param[in] filename The path to the input file
+    @param[in,out] mrmfqc The output class which will contain the criteria
+    @param[in] is_component_group true if the user intends to load ComponentGroupQCs data, false otherwise
   */
-  void load(const String& filename, MRMFeatureQC& mrmfqc) const;
+  void load(const String& filename, MRMFeatureQC& mrmfqc, const bool is_component_group) const;
 
   /*
     @brief Stores an MRMFeatureQC file.

--- a/src/openms/include/OpenMS/FORMAT/MRMFeatureQCFile.h
+++ b/src/openms/include/OpenMS/FORMAT/MRMFeatureQCFile.h
@@ -127,6 +127,27 @@ protected:
     std::map<String, std::pair<double,double>>& meta_values_qc
   ) const;
 
+  Int getCastValue_(
+    const std::map<String, Size>& headers,
+    const StringList& line,
+    const String& header,
+    const Int default_value
+  ) const;
+
+  double getCastValue_(
+    const std::map<String, Size>& headers,
+    const StringList& line,
+    const String& header,
+    const double default_value
+  ) const;
+
+  String getCastValue_(
+    const std::map<String, Size>& headers,
+    const StringList& line,
+    const String& header,
+    const String& default_value
+  ) const;
+
   };
 
 } // namespace OpenMS

--- a/src/openms/include/OpenMS/FORMAT/MRMFeatureQCFile.h
+++ b/src/openms/include/OpenMS/FORMAT/MRMFeatureQCFile.h
@@ -28,8 +28,8 @@
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // --------------------------------------------------------------------------
-// $Maintainer: Douglas McCloskey $
-// $Authors: Douglas McCloskey $
+// $Maintainer: Douglas McCloskey, Pasquale Domenico Colaianni $
+// $Authors: Douglas McCloskey, Pasquale Domenico Colaianni $
 // --------------------------------------------------------------------------
 
 #ifndef OPENMS_FORMAT_MRMFEATUREQCFILE_H
@@ -54,10 +54,10 @@ namespace OpenMS
     public ProgressLogger
   {
 public:
-  ///Default constructor
-  MRMFeatureQCFile();
-  ///Destructor
-  ~MRMFeatureQCFile() override;
+  /// Default constructor
+  MRMFeatureQCFile() = default;
+  /// Destructor
+  ~MRMFeatureQCFile() = default;
 
   /**
     @brief Loads an MRMFeatureQC file.
@@ -65,35 +65,36 @@ public:
     @exception Exception::FileNotFound is thrown if the file could not be opened
     @exception Exception::ParseError is thrown if an error occurs during parsing
   */
-  void load(const String & filename, MRMFeatureQC & mrmfqc);
+  void load(const String& filename, MRMFeatureQC& mrmfqc) const;
 
-  /**
+  /*
     @brief Stores an MRMFeatureQC file.
 
     @exception Exception::UnableToCreateFile is thrown if the file could not be created
   */
-  void store(const String & filename, const MRMFeatureQC & mrmfqc);
+//  void store(const String& filename, const MRMFeatureQC& mrmfqc);
 
 
 protected:
-  /**
-    @brief Checks if a file is valid with respect to the mapping file and the controlled vocabulary.
 
-    @param line Header line of the .csv file.
-    @param headers A map of header strings to column positions.
-    @param params_headers A map of transformation model parameter header strings to column positions.
-  */
-  void parseHeader_(StringList & line, std::map<String, int> & headers,
-    std::map<String, int> & params_headers);
+  void pushValuesFromLine_(
+    const StringList& line,
+    const std::map<String, Size>& headers,
+    std::vector<MRMFeatureQC::ComponentQCs>& c_qcs
+  ) const;
 
-  /**
-    @brief parses a line into the members of MRMFeatureQC.
+  void pushValuesFromLine_(
+    const StringList& line,
+    const std::map<String, Size>& headers,
+    std::vector<MRMFeatureQC::ComponentGroupQCs>& cg_qcs
+  ) const;
 
-    @param line line of the .csv file.
-    @param aqm MRMFeatureQC.
-  */
-  void parseLine_(StringList & line, std::map<String, int> & headers, 
-    std::map<String, int> & params_headers, MRMFeatureQC & mrmfqc);
+  void setPairValue_(
+    const String& key,
+    const String& value,
+    const String& boundary,
+    std::map<String, std::pair<double,double>>& meta_values_qc
+  ) const;
 
   };
 

--- a/src/openms/source/FORMAT/MRMFeatureQCFile.cpp
+++ b/src/openms/source/FORMAT/MRMFeatureQCFile.cpp
@@ -101,7 +101,7 @@ namespace OpenMS
       const String& header = h.first;
       const Size& i = h.second;
       boost::smatch m;
-      if (boost::regex_search(header, m, boost::regex("metaValue_(.+)_(l|u)")))
+      if (boost::regex_search(header, m, boost::regex("metaValue_(.+)_(l|u)"))) // capture the metavalue name and the boundary and save them to m[1] and m[2]
       {
         setPairValue_(String(m[1]), line[i], String(m[2]), c.meta_value_qc);
       }
@@ -171,7 +171,7 @@ namespace OpenMS
       const String& header = h.first;
       const Size& i = h.second;
       boost::smatch m;
-      if (boost::regex_search(header, m, boost::regex("metaValue_(.+)_(l|u)")))
+      if (boost::regex_search(header, m, boost::regex("metaValue_(.+)_(l|u)"))) // capture the metavalue name and the boundary and save them to m[1] and m[2]
       {
         setPairValue_(String(m[1]), line[i], String(m[2]), cg.meta_value_qc);
       }

--- a/src/openms/source/FORMAT/MRMFeatureQCFile.cpp
+++ b/src/openms/source/FORMAT/MRMFeatureQCFile.cpp
@@ -81,22 +81,14 @@ namespace OpenMS
   ) const
   {
     MRMFeatureQC::ComponentQCs c;
-    std::map<String, Size>::const_iterator it;
-    it = headers.find("component_name");
-    c.component_name = it != headers.end() ? line[it->second] : "";
+    c.component_name = getCastValue_(headers, line, "component_name", "");
     if (c.component_name.empty()) return;
-    it = headers.find("retention_time_l");
-    c.retention_time_l = it != headers.end() ? line[it->second].toDouble() : 0.0;
-    it = headers.find("retention_time_u");
-    c.retention_time_u = it != headers.end() ? line[it->second].toDouble() : 100.0;
-    it = headers.find("intensity_l");
-    c.intensity_l = it != headers.end() ? line[it->second].toDouble() : 0.0;
-    it = headers.find("intensity_u");
-    c.intensity_u = it != headers.end() ? line[it->second].toDouble() : 1e12;
-    it = headers.find("overall_quality_l");
-    c.overall_quality_l = it != headers.end() ? line[it->second].toDouble() : 0.0;
-    it = headers.find("overall_quality_u");
-    c.overall_quality_u = it != headers.end() ? line[it->second].toDouble() : 1e12;
+    c.retention_time_l = getCastValue_(headers, line, "retention_time_l", 0.0);
+    c.retention_time_u = getCastValue_(headers, line, "retention_time_u", 100.0);
+    c.intensity_l = getCastValue_(headers, line, "intensity_l", 0.0);
+    c.intensity_u = getCastValue_(headers, line, "intensity_u", 1e12);
+    c.overall_quality_l = getCastValue_(headers, line, "overall_quality_l", 0.0);
+    c.overall_quality_u = getCastValue_(headers, line, "overall_quality_u", 1e12);
     for (const std::pair<String, Size>& h : headers) // parse the parameters
     {
       const String& header = h.first;
@@ -117,57 +109,31 @@ namespace OpenMS
   ) const
   {
     MRMFeatureQC::ComponentGroupQCs cg;
-    std::map<String, Size>::const_iterator it;
-    it = headers.find("component_group_name");
-    cg.component_group_name = it != headers.end() ? line[it->second] : "";
+    cg.component_group_name = getCastValue_(headers, line, "component_group_name", "");
     if (cg.component_group_name.empty()) return;
-    it = headers.find("retention_time_l");
-    cg.retention_time_l = it != headers.end() ? line[it->second].toDouble() : 0.0;
-    it = headers.find("retention_time_u");
-    cg.retention_time_u = it != headers.end() ? line[it->second].toDouble() : 100.0;
-    it = headers.find("intensity_l");
-    cg.intensity_l = it != headers.end() ? line[it->second].toDouble() : 0.0;
-    it = headers.find("intensity_u");
-    cg.intensity_u = it != headers.end() ? line[it->second].toDouble() : 1e12;
-    it = headers.find("overall_quality_l");
-    cg.overall_quality_l = it != headers.end() ? line[it->second].toDouble() : 0.0;
-    it = headers.find("overall_quality_u");
-    cg.overall_quality_u = it != headers.end() ? line[it->second].toDouble() : 1e12;
-    it = headers.find("n_heavy_l");
-    cg.n_heavy_l = it != headers.end() ? line[it->second].toInt() : 0;
-    it = headers.find("n_heavy_u");
-    cg.n_heavy_u = it != headers.end() ? line[it->second].toInt() : 100;
-    it = headers.find("n_light_l");
-    cg.n_light_l = it != headers.end() ? line[it->second].toInt() : 0;
-    it = headers.find("n_light_u");
-    cg.n_light_u = it != headers.end() ? line[it->second].toInt() : 100;
-    it = headers.find("n_detecting_l");
-    cg.n_detecting_l = it != headers.end() ? line[it->second].toInt() : 0;
-    it = headers.find("n_detecting_u");
-    cg.n_detecting_u = it != headers.end() ? line[it->second].toInt() : 100;
-    it = headers.find("n_quantifying_l");
-    cg.n_quantifying_l = it != headers.end() ? line[it->second].toInt() : 0;
-    it = headers.find("n_quantifying_u");
-    cg.n_quantifying_u = it != headers.end() ? line[it->second].toInt() : 100;
-    it = headers.find("n_identifying_l");
-    cg.n_identifying_l = it != headers.end() ? line[it->second].toInt() : 0;
-    it = headers.find("n_identifying_u");
-    cg.n_identifying_u = it != headers.end() ? line[it->second].toInt() : 100;
-    it = headers.find("n_transitions_l");
-    cg.n_transitions_l = it != headers.end() ? line[it->second].toInt() : 0;
-    it = headers.find("n_transitions_u");
-    cg.n_transitions_u = it != headers.end() ? line[it->second].toInt() : 100;
-    it = headers.find("ion_ratio_pair_name_1");
-    cg.ion_ratio_pair_name_1 = it != headers.end() ? line[it->second] : "";
-    it = headers.find("ion_ratio_pair_name_2");
-    cg.ion_ratio_pair_name_2 = it != headers.end() ? line[it->second] : "";
-    it = headers.find("ion_ratio_l");
-    cg.ion_ratio_l = it != headers.end() ? line[it->second].toDouble() : 0.0;
-    it = headers.find("ion_ratio_u");
-    cg.ion_ratio_u = it != headers.end() ? line[it->second].toDouble() : 1e12;
-    it = headers.find("ion_ratio_feature_name");
-    cg.ion_ratio_feature_name = it != headers.end() ? line[it->second] : "";
-
+    cg.retention_time_l = getCastValue_(headers, line, "retention_time_l", 0.0);
+    cg.retention_time_u = getCastValue_(headers, line, "retention_time_u", 100.0);
+    cg.intensity_l = getCastValue_(headers, line, "intensity_l", 0.0);
+    cg.intensity_u = getCastValue_(headers, line, "intensity_u", 1e12);
+    cg.overall_quality_l = getCastValue_(headers, line, "overall_quality_l", 0.0);
+    cg.overall_quality_u = getCastValue_(headers, line, "overall_quality_u", 1e12);
+    cg.n_heavy_l = getCastValue_(headers, line, "n_heavy_l", 0);
+    cg.n_heavy_u = getCastValue_(headers, line, "n_heavy_u", 100);
+    cg.n_light_l = getCastValue_(headers, line, "n_light_l", 0);
+    cg.n_light_u = getCastValue_(headers, line, "n_light_u", 100);
+    cg.n_detecting_l = getCastValue_(headers, line, "n_detecting_l", 0);
+    cg.n_detecting_u = getCastValue_(headers, line, "n_detecting_u", 100);
+    cg.n_quantifying_l = getCastValue_(headers, line, "n_quantifying_l", 0);
+    cg.n_quantifying_u = getCastValue_(headers, line, "n_quantifying_u", 100);
+    cg.n_identifying_l = getCastValue_(headers, line, "n_identifying_l", 0);
+    cg.n_identifying_u = getCastValue_(headers, line, "n_identifying_u", 100);
+    cg.n_transitions_l = getCastValue_(headers, line, "n_transitions_l", 0);
+    cg.n_transitions_u = getCastValue_(headers, line, "n_transitions_u", 100);
+    cg.ion_ratio_pair_name_1 = getCastValue_(headers, line, "ion_ratio_pair_name_1", "");
+    cg.ion_ratio_pair_name_2 = getCastValue_(headers, line, "ion_ratio_pair_name_2", "");
+    cg.ion_ratio_l = getCastValue_(headers, line, "ion_ratio_l", 0.0);
+    cg.ion_ratio_u = getCastValue_(headers, line, "ion_ratio_u", 1e12);
+    cg.ion_ratio_feature_name = getCastValue_(headers, line, "ion_ratio_feature_name", "");
     for (const std::pair<String, Size>& h : headers) // parse the parameters
     {
       const String& header = h.first;
@@ -189,17 +155,57 @@ namespace OpenMS
   ) const
   {
     std::map<String, std::pair<double,double>>::iterator it = meta_values_qc.find(key);
+    const double cast_value = value.empty() ? (boundary == "l" ? 0.0 : 1e12) : std::stod(value);
     if (it != meta_values_qc.end())
     {
-      if (boundary == "l") it->second.first = value.toDouble();
-      else it->second.second = value.toDouble();
+      if (boundary == "l") it->second.first = cast_value;
+      else it->second.second = cast_value;
     }
     else
     {
       meta_values_qc[key] = boundary == "l"
-        ? std::make_pair(value.toDouble(), 0.0)
-        : std::make_pair(0.0, value.toDouble());
+        ? std::make_pair(cast_value, 1e12)
+        : std::make_pair(0.0, cast_value);
     }
+  }
+
+  Int MRMFeatureQCFile::getCastValue_(
+    const std::map<String, Size>& headers,
+    const StringList& line,
+    const String& header,
+    const Int default_value
+  ) const
+  {
+    std::map<String, Size>::const_iterator it = headers.find(header);
+    return it != headers.end() && !line[it->second].empty()
+      ? std::stoi(line[it->second])
+      : default_value;
+  }
+
+  double MRMFeatureQCFile::getCastValue_(
+    const std::map<String, Size>& headers,
+    const StringList& line,
+    const String& header,
+    const double default_value
+  ) const
+  {
+    std::map<String, Size>::const_iterator it = headers.find(header);
+    return it != headers.end() && !line[it->second].empty()
+      ? std::stod(line[it->second])
+      : default_value;
+  }
+
+  String MRMFeatureQCFile::getCastValue_(
+    const std::map<String, Size>& headers,
+    const StringList& line,
+    const String& header,
+    const String& default_value
+  ) const
+  {
+    std::map<String, Size>::const_iterator it = headers.find(header);
+    return it != headers.end() && !line[it->second].empty()
+      ? line[it->second]
+      : default_value;
   }
 
   //TODO

--- a/src/openms/source/FORMAT/MRMFeatureQCFile.cpp
+++ b/src/openms/source/FORMAT/MRMFeatureQCFile.cpp
@@ -84,18 +84,19 @@ namespace OpenMS
     std::map<String, Size>::const_iterator it;
     it = headers.find("component_name");
     c.component_name = it != headers.end() ? line[it->second] : "";
+    if (c.component_name.empty()) return;
     it = headers.find("retention_time_l");
     c.retention_time_l = it != headers.end() ? line[it->second].toDouble() : 0.0;
     it = headers.find("retention_time_u");
-    c.retention_time_u = it != headers.end() ? line[it->second].toDouble() : 0.0;
+    c.retention_time_u = it != headers.end() ? line[it->second].toDouble() : 100.0;
     it = headers.find("intensity_l");
     c.intensity_l = it != headers.end() ? line[it->second].toDouble() : 0.0;
     it = headers.find("intensity_u");
-    c.intensity_u = it != headers.end() ? line[it->second].toDouble() : 0.0;
+    c.intensity_u = it != headers.end() ? line[it->second].toDouble() : 1e12;
     it = headers.find("overall_quality_l");
     c.overall_quality_l = it != headers.end() ? line[it->second].toDouble() : 0.0;
     it = headers.find("overall_quality_u");
-    c.overall_quality_u = it != headers.end() ? line[it->second].toDouble() : 0.0;
+    c.overall_quality_u = it != headers.end() ? line[it->second].toDouble() : 1e12;
     for (const std::pair<String, Size>& h : headers) // parse the parameters
     {
       const String& header = h.first;
@@ -106,7 +107,7 @@ namespace OpenMS
         setPairValue_(String(m[1]), line[i], String(m[2]), c.meta_value_qc);
       }
     }
-    c_qcs.push_back(c); // TODO: check for any condition before pushing?
+    c_qcs.push_back(c);
   }
 
   void MRMFeatureQCFile::pushValuesFromLine_(
@@ -119,42 +120,43 @@ namespace OpenMS
     std::map<String, Size>::const_iterator it;
     it = headers.find("component_group_name");
     cg.component_group_name = it != headers.end() ? line[it->second] : "";
+    if (cg.component_group_name.empty()) return;
     it = headers.find("retention_time_l");
     cg.retention_time_l = it != headers.end() ? line[it->second].toDouble() : 0.0;
     it = headers.find("retention_time_u");
-    cg.retention_time_u = it != headers.end() ? line[it->second].toDouble() : 0.0;
+    cg.retention_time_u = it != headers.end() ? line[it->second].toDouble() : 100.0;
     it = headers.find("intensity_l");
     cg.intensity_l = it != headers.end() ? line[it->second].toDouble() : 0.0;
     it = headers.find("intensity_u");
-    cg.intensity_u = it != headers.end() ? line[it->second].toDouble() : 0.0;
+    cg.intensity_u = it != headers.end() ? line[it->second].toDouble() : 1e12;
     it = headers.find("overall_quality_l");
     cg.overall_quality_l = it != headers.end() ? line[it->second].toDouble() : 0.0;
     it = headers.find("overall_quality_u");
-    cg.overall_quality_u = it != headers.end() ? line[it->second].toDouble() : 0.0;
+    cg.overall_quality_u = it != headers.end() ? line[it->second].toDouble() : 1e12;
     it = headers.find("n_heavy_l");
     cg.n_heavy_l = it != headers.end() ? line[it->second].toInt() : 0;
     it = headers.find("n_heavy_u");
-    cg.n_heavy_u = it != headers.end() ? line[it->second].toInt() : 0;
+    cg.n_heavy_u = it != headers.end() ? line[it->second].toInt() : 100;
     it = headers.find("n_light_l");
     cg.n_light_l = it != headers.end() ? line[it->second].toInt() : 0;
     it = headers.find("n_light_u");
-    cg.n_light_u = it != headers.end() ? line[it->second].toInt() : 0;
+    cg.n_light_u = it != headers.end() ? line[it->second].toInt() : 100;
     it = headers.find("n_detecting_l");
     cg.n_detecting_l = it != headers.end() ? line[it->second].toInt() : 0;
     it = headers.find("n_detecting_u");
-    cg.n_detecting_u = it != headers.end() ? line[it->second].toInt() : 0;
+    cg.n_detecting_u = it != headers.end() ? line[it->second].toInt() : 100;
     it = headers.find("n_quantifying_l");
     cg.n_quantifying_l = it != headers.end() ? line[it->second].toInt() : 0;
     it = headers.find("n_quantifying_u");
-    cg.n_quantifying_u = it != headers.end() ? line[it->second].toInt() : 0;
+    cg.n_quantifying_u = it != headers.end() ? line[it->second].toInt() : 100;
     it = headers.find("n_identifying_l");
     cg.n_identifying_l = it != headers.end() ? line[it->second].toInt() : 0;
     it = headers.find("n_identifying_u");
-    cg.n_identifying_u = it != headers.end() ? line[it->second].toInt() : 0;
+    cg.n_identifying_u = it != headers.end() ? line[it->second].toInt() : 100;
     it = headers.find("n_transitions_l");
     cg.n_transitions_l = it != headers.end() ? line[it->second].toInt() : 0;
     it = headers.find("n_transitions_u");
-    cg.n_transitions_u = it != headers.end() ? line[it->second].toInt() : 0;
+    cg.n_transitions_u = it != headers.end() ? line[it->second].toInt() : 100;
     it = headers.find("ion_ratio_pair_name_1");
     cg.ion_ratio_pair_name_1 = it != headers.end() ? line[it->second] : "";
     it = headers.find("ion_ratio_pair_name_2");
@@ -162,7 +164,7 @@ namespace OpenMS
     it = headers.find("ion_ratio_l");
     cg.ion_ratio_l = it != headers.end() ? line[it->second].toDouble() : 0.0;
     it = headers.find("ion_ratio_u");
-    cg.ion_ratio_u = it != headers.end() ? line[it->second].toDouble() : 0.0;
+    cg.ion_ratio_u = it != headers.end() ? line[it->second].toDouble() : 1e12;
     it = headers.find("ion_ratio_feature_name");
     cg.ion_ratio_feature_name = it != headers.end() ? line[it->second] : "";
 
@@ -176,7 +178,7 @@ namespace OpenMS
         setPairValue_(String(m[1]), line[i], String(m[2]), cg.meta_value_qc);
       }
     }
-    cg_qcs.push_back(cg); // TODO: check for any condition before pushing?
+    cg_qcs.push_back(cg);
   }
 
   void MRMFeatureQCFile::setPairValue_(

--- a/src/openms/source/FORMAT/MRMFeatureQCFile.cpp
+++ b/src/openms/source/FORMAT/MRMFeatureQCFile.cpp
@@ -41,7 +41,7 @@
 
 namespace OpenMS
 {
-  void MRMFeatureQCFile::load(const String& filename, MRMFeatureQC& mrmfqc) const
+  void MRMFeatureQCFile::load(const String& filename, MRMFeatureQC& mrmfqc, const bool is_component_group) const
   {
     CsvFile csv(filename, ',', false, -1);
     StringList sl;
@@ -54,7 +54,7 @@ namespace OpenMS
     {
       headers[sl[i]] = i; // for each header found, assign an index value to it
     }
-    if (headers.count("component_name")) // load component file
+    if (!is_component_group) // load component file
     {
       mrmfqc.component_qcs.clear();
       for (Size i = 1; i < csv.rowCount(); ++i)
@@ -63,7 +63,7 @@ namespace OpenMS
         pushValuesFromLine_(sl, headers, mrmfqc.component_qcs);
       }
     }
-    else if (headers.count("component_group_name")) // load component group file
+    else // load component group file
     {
       mrmfqc.component_group_qcs.clear();
       for (Size i = 1; i < csv.rowCount(); ++i)
@@ -71,10 +71,6 @@ namespace OpenMS
         csv.getRow(i, sl);
         pushValuesFromLine_(sl, headers, mrmfqc.component_group_qcs);
       }
-    }
-    else
-    {
-      throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "The file must contain one of the two following columns: component_name, component_group_name.");
     }
   }
 

--- a/src/tests/class_tests/openms/data/MRMFeatureQCFile_1.csv
+++ b/src/tests/class_tests/openms/data/MRMFeatureQCFile_1.csv
@@ -1,4 +1,4 @@
-component_name,component_group_name,n_heavy_l ,n_heavy_u,n_light_l,n_light_u,n_detecting_l,n_detecting_u,n_quantifying_l,n_quantifying_u,n_identifying_l,n_identifying_u,n_transitions_l,n_transitions_u,ion_ratio_pair_name_1,ion_ratio_pair_name_2,ion_ratio_l,ion_ratio_u,retention_time_l,retention_time_u,intensity_l,intensity_u,overall_quality_l,overall_quality_u,metaValue_peak_apex_int_l,metaValue_peak_apex_int_u,metaValue_sn_score_l,metaValue_sn_score_u
-component1,componentGroup1,1,1,1,3,2,4,2,4,0,4,2,4,component1,component2,0.5,0.6,1,2,1000,1000000,2,5,1000,1000000,2,10
-component2,componentGroup2,1,1,1,3,2,4,2,4,0,4,2,4,component1,component2,0.5,0.6,1,2,1000,1000000,2,5,1000,1000000,5,20
-component3,componentGroup3,1,1,1,3,2,4,2,4,0,4,2,4,component1,component2,0.5,0.6,1,2,1000,1000000,2,5,1000,1000000,10,50
+component_name,retention_time_l,retention_time_u,intensity_l,intensity_u,overall_quality_l,overall_quality_u,metaValue_peak_apex_int_l,metaValue_peak_apex_int_u,metaValue_sn_score_l,metaValue_sn_score_u
+component1,1,2,1000,1000000,2,5,1000,1000000,2,10
+component2,3,4,2000,2000000,3,6,2000,2000000,5,20
+component3,5,6,3000,3000000,4,7,3000,3000000,10,50

--- a/src/tests/class_tests/openms/data/MRMFeatureQCFile_1.csv
+++ b/src/tests/class_tests/openms/data/MRMFeatureQCFile_1.csv
@@ -2,3 +2,5 @@ component_name,retention_time_l,retention_time_u,intensity_l,intensity_u,overall
 component1,1,2,1000,1000000,2,5,1000,1000000,2,10
 component2,3,4,2000,2000000,3,6,2000,2000000,5,20
 component3,5,6,3000,3000000,4,7,3000,3000000,10,50
+,6,7,3010,3000100,41,71,3100,3001000,15,60
+component4,,,,,,,,,,

--- a/src/tests/class_tests/openms/data/MRMFeatureQCFile_2.csv
+++ b/src/tests/class_tests/openms/data/MRMFeatureQCFile_2.csv
@@ -1,0 +1,4 @@
+component_group_name,n_heavy_l ,n_heavy_u,n_light_l,n_light_u,n_detecting_l,n_detecting_u,n_quantifying_l,n_quantifying_u,n_identifying_l,n_identifying_u,n_transitions_l,n_transitions_u,ion_ratio_pair_name_1,ion_ratio_pair_name_2,ion_ratio_l,ion_ratio_u,retention_time_l,retention_time_u,intensity_l,intensity_u,overall_quality_l,overall_quality_u,metaValue_peak_apex_int_l,metaValue_peak_apex_int_u,metaValue_sn_score_l,metaValue_sn_score_u
+componentGroup1,1,1,1,3,2,4,2,4,0,4,2,4,component1,component2,0.5,0.6,1,2,1000,1000000,2,5,1000,1000000,2,10
+componentGroup2,1,1,1,3,2,4,2,4,0,4,2,4,component1,component2,0.5,0.6,1,2,1000,1000000,2,5,1000,1000000,5,20
+componentGroup3,1,1,1,3,2,4,2,4,0,4,2,4,component1,component2,0.5,0.6,1,2,1000,1000000,2,5,1000,1000000,10,50

--- a/src/tests/class_tests/openms/data/MRMFeatureQCFile_2.csv
+++ b/src/tests/class_tests/openms/data/MRMFeatureQCFile_2.csv
@@ -1,4 +1,6 @@
-component_group_name,n_heavy_l ,n_heavy_u,n_light_l,n_light_u,n_detecting_l,n_detecting_u,n_quantifying_l,n_quantifying_u,n_identifying_l,n_identifying_u,n_transitions_l,n_transitions_u,ion_ratio_pair_name_1,ion_ratio_pair_name_2,ion_ratio_l,ion_ratio_u,retention_time_l,retention_time_u,intensity_l,intensity_u,overall_quality_l,overall_quality_u,metaValue_peak_apex_int_l,metaValue_peak_apex_int_u,metaValue_sn_score_l,metaValue_sn_score_u
-componentGroup1,1,1,1,3,2,4,2,4,0,4,2,4,component1,component2,0.5,0.6,1,2,1000,1000000,2,5,1000,1000000,2,10
-componentGroup2,1,1,1,3,2,4,2,4,0,4,2,4,component1,component2,0.5,0.6,1,2,1000,1000000,2,5,1000,1000000,5,20
-componentGroup3,1,1,1,3,2,4,2,4,0,4,2,4,component1,component2,0.5,0.6,1,2,1000,1000000,2,5,1000,1000000,10,50
+component_group_name,n_heavy_l,n_heavy_u,n_light_l,n_light_u,n_detecting_l,n_detecting_u,n_quantifying_l,n_quantifying_u,n_identifying_l,n_identifying_u,n_transitions_l,n_transitions_u,ion_ratio_pair_name_1,ion_ratio_pair_name_2,ion_ratio_l,ion_ratio_u,ion_ratio_feature_name,retention_time_l,retention_time_u,intensity_l,intensity_u,overall_quality_l,overall_quality_u,metaValue_peak_apex_int_l,metaValue_peak_apex_int_u,metaValue_sn_score_l,metaValue_sn_score_u
+componentGroup1,1,2,3,4,5,6,7,8,9,10,11,12,component1,component2,0.5,0.6,feature1,1,2,1000,1000000,2,5,1000,1000000,2,10
+componentGroup2,2,3,4,5,6,7,8,9,10,11,12,13,component3,component4,1.5,1.6,feature2,2,3,1001,1000001,3,6,1001,1000001,5,20
+componentGroup3,3,4,5,6,7,8,9,10,11,12,13,14,component5,component6,2.5,2.6,feature3,3,4,1002,1000002,4,7,1002,1000002,10,50
+,4,5,6,7,8,9,10,11,12,13,14,15,component7,component8,3.5,3.6,feature4,4,5,1003,1000003,5,8,1003,1000003,11,51
+componentGroup5,,,,,,,,,,,,,,,,,,,,,,,,,,,

--- a/src/tests/class_tests/openms/source/MRMFeatureQCFile_test.cpp
+++ b/src/tests/class_tests/openms/source/MRMFeatureQCFile_test.cpp
@@ -28,8 +28,8 @@
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // 
 // --------------------------------------------------------------------------
-// $Maintainer: Douglas McCloskey $
-// $Authors: Douglas McCloskey $
+// $Maintainer: Douglas McCloskey, Pasquale Domenico Colaianni $
+// $Authors: Douglas McCloskey, Pasquale Domenico Colaianni $
 // --------------------------------------------------------------------------
 #include <OpenMS/CONCEPT/ClassTest.h>
 #include <OpenMS/test_config.h>
@@ -39,24 +39,6 @@
 
 using namespace OpenMS;
 using namespace std;
-
-class MRMFeatureQCFile_facade : MRMFeatureQCFile
-{
-  public:
-
-    void parseHeader_(StringList & line, std::map<String, int> & headers,
-    std::map<String, int> & params_headers)
-    {
-      MRMFeatureQCFile::parseHeader_(line, headers, params_headers);
-    }
-
-    void parseLine_(StringList & line, std::map<String,int> & headers, 
-    std::map<String,int> & params_headers,
-    MRMFeatureQC & mrmfqc)
-    {
-      MRMFeatureQCFile::parseLine_(line, headers, params_headers, mrmfqc);
-    }
-};
 
 START_TEST(MRMFeatureQCFile, "$Id$")
 
@@ -79,208 +61,23 @@ START_SECTION(~MRMFeatureQCFile())
 }
 END_SECTION
 
-START_SECTION((void parseHeader_(StringList & line, std::map<String,int> & headers,
-    std::map<String,int> & params_headers)))
-    //TODO
-
-    MRMFeatureQCFile_facade mrmfqcfile;
-    
-    std::map<String,int> headers;
-    std::map<String,int> params_headers;
-  
-    // header test 1
-    StringList header1; 
-    header1.push_back("component_name");
-    header1.push_back("component_group_name");
-    header1.push_back("n_heavy_l"); 
-    header1.push_back("n_heavy_u");
-    header1.push_back("n_light_l");
-    header1.push_back("n_light_u");
-    header1.push_back("n_detecting_l");
-    header1.push_back("n_detecting_u");
-    header1.push_back("n_quantifying_l");
-    header1.push_back("n_quantifying_u");
-    header1.push_back("n_identifying_l");
-    header1.push_back("n_identifying_u");
-    header1.push_back("n_transitions_l");
-    header1.push_back("n_transitions_u");
-    header1.push_back("ion_ratio_pair_name_1");
-    header1.push_back("ion_ratio_pair_name_2");
-    header1.push_back("ion_ratio_l");
-    header1.push_back("ion_ratio_u");
-    header1.push_back("ion_ratio_feature_name");
-    header1.push_back("retention_time_l");
-    header1.push_back("retention_time_u");
-    header1.push_back("intensity_l");
-    header1.push_back("intensity_u");
-    header1.push_back("overall_quality_l");
-    header1.push_back("overall_quality_u");
-    header1.push_back("metaValue_peak_apex_int_l");
-    header1.push_back("metaValue_peak_apex_int_u");
-    header1.push_back("metaValue_sn_score_l");
-    header1.push_back("metaValue_sn_score_u");
-  
-    mrmfqcfile.parseHeader_(header1, headers, params_headers);
-  
-    TEST_EQUAL(headers["component_name"], 0);
-    TEST_EQUAL(headers["n_detecting_u"], 7);
-    TEST_EQUAL(headers["overall_quality_u"], 24);
-    TEST_EQUAL(params_headers["peak_apex_int_l"], 25);
-    TEST_EQUAL(params_headers["sn_score_u"], 28);
-  
-    headers.clear();
-    params_headers.clear();
-    
-    // header test 2
-    StringList header2; 
-    header2.push_back("component_name");
-    header2.push_back("component_group_name");
-    header2.push_back("n_heavy_l"); 
-    header2.push_back("n_heavy_u");
-    header2.push_back("n_light_l");
-    header2.push_back("n_light_u");
-    header2.push_back("n_detecting_l");
-    // header2.push_back("n_detecting_u");
-    header2.push_back("n_quantifying_l");
-    header2.push_back("n_quantifying_u");
-    header2.push_back("n_identifying_l");
-    header2.push_back("n_identifying_u");
-    header2.push_back("n_transitions_l");
-    header2.push_back("n_transitions_u");
-    header2.push_back("ion_ratio_pair_name_1");
-    header2.push_back("ion_ratio_pair_name_2");
-    header2.push_back("ion_ratio_l");
-    header2.push_back("ion_ratio_u");
-    // header2.push_back("ion_ratio_feature_name");
-    header2.push_back("retention_time_l");
-    header2.push_back("retention_time_u");
-    header2.push_back("intensity_l");
-    header2.push_back("intensity_u");
-    header2.push_back("overall_quality_l");
-    header2.push_back("overall_quality_u");
-    header2.push_back("metaValue_peak_apex_int_l");
-    header2.push_back("metaValue_peak_apex_int_u");
-    header2.push_back("metaValue_sn_score_l");
-    header2.push_back("metaValue_sn_score_u");
-  
-    mrmfqcfile.parseHeader_(header2, headers, params_headers);
-    
-    TEST_EQUAL(headers["component_name"], 0);
-    TEST_EQUAL(headers["n_detecting_u"], -1);
-    TEST_EQUAL(headers["overall_quality_u"], 22);
-    TEST_EQUAL(params_headers["peak_apex_int_l"], 23);
-    TEST_EQUAL(params_headers["sn_score_u"], 26);
-    
-  END_SECTION
-  
-  START_SECTION((void parseLine_(StringList & line, std::map<String,int> & headers, 
-    std::map<String,int> & params_headers, MRMFeatureQC & mrmfqc)))
-    
-    MRMFeatureQCFile_facade mrmfqcfile;
-    MRMFeatureQC mrmfqc;
-    
-    // headers
-    std::map<String,int> headers;
-    std::map<String,int> params_headers;
-    headers["component_name"] = 0;
-    headers["component_group_name"] = 1;
-    headers["n_heavy_l"] = 2;
-    headers["n_heavy_u"] = 3;
-    headers["n_light_l"] = 4;
-    headers["n_light_u"] = 5;
-    headers["n_detecting_l"] = 6;
-    headers["n_detecting_u"] = 7;
-    headers["n_quantifying_l"] = 8;
-    headers["n_quantifying_u"] = 9;
-    headers["n_identifying_l"] = 10;
-    headers["n_identifying_u"] = 11;
-    headers["n_transitions_l"] = 12;
-    headers["n_transitions_u"] = 13;
-    headers["ion_ratio_pair_name_1"] = 14;
-    headers["ion_ratio_pair_name_2"] = 15;
-    headers["ion_ratio_l"] = 16;
-    headers["ion_ratio_u"] = 17;
-    headers["ion_ratio_feature_name"] = 18;
-    headers["retention_time_l"] = 19;
-    headers["retention_time_u"] = 20;
-    headers["intensity_l"] = 21;
-    headers["intensity_u"] = 22;
-    headers["overall_quality_l"] = 23;
-    headers["overall_quality_u"] = 24;
-    params_headers["peak_apex_int_l"] = 25;
-    params_headers["peak_apex_int_u"] = 26;
-    params_headers["sn_score_l"] = 27;
-    params_headers["sn_score_u"] = 28;
-  
-    // line test 1
-    StringList line1; 
-    line1.push_back("component1");
-    line1.push_back("component_group1");
-    line1.push_back(1);
-    line1.push_back(1);
-    line1.push_back(2);
-    line1.push_back(2);
-    line1.push_back(0);
-    line1.push_back(0);
-    line1.push_back(1);
-    line1.push_back(1);
-    line1.push_back(2);
-    line1.push_back(2);
-    line1.push_back(3);
-    line1.push_back(3);
-    line1.push_back("component1");
-    line1.push_back("component2");
-    line1.push_back(0.5);
-    line1.push_back(0.75);
-    line1.push_back("peak_apex_int");
-    line1.push_back(1.0);
-    line1.push_back(2.0);
-    line1.push_back(1.0e3);
-    line1.push_back(1.0e5);
-    line1.push_back(2.0);
-    line1.push_back(5.0);  
-    line1.push_back(1.1e3);
-    line1.push_back(1.1e5);
-    line1.push_back(2.0);
-    line1.push_back(10.0);
-
-    mrmfqcfile.parseLine_(line1, headers, params_headers, mrmfqc);
-  
-    TEST_EQUAL(mrmfqc.component_group_qcs[0].component_group_name, "component_group1");
-    TEST_EQUAL(mrmfqc.component_group_qcs[0].n_quantifying_u, 1);
-
-    TEST_EQUAL(mrmfqc.component_qcs[0].component_name, "component1");
-    TEST_REAL_SIMILAR(mrmfqc.component_qcs[0].retention_time_l, 1.0);
-    TEST_REAL_SIMILAR(mrmfqc.component_qcs[0].overall_quality_u, 5.0);
-    TEST_REAL_SIMILAR(mrmfqc.component_qcs[0].meta_value_qc["peak_apex_int"].first, 1.1e3);
-    TEST_REAL_SIMILAR(mrmfqc.component_qcs[0].meta_value_qc["sn_score"].second, 10.0);
-  
-    headers.clear();
-    
-  END_SECTION
-  
-  START_SECTION((void load(const String & filename, MRMFeatureQC & mrmfqc)))
-    MRMFeatureQCFile mrmfqcfile;
-    MRMFeatureQC mrmfqc;
-  
-    mrmfqcfile.load(OPENMS_GET_TEST_DATA_PATH("MRMFeatureQCFile_1.csv"), mrmfqc);
-    // first line
-    TEST_EQUAL(mrmfqc.component_group_qcs[0].component_group_name, "componentGroup1");
-    TEST_EQUAL(mrmfqc.component_qcs[0].component_name, "component1");
-    TEST_REAL_SIMILAR(mrmfqc.component_qcs[0].meta_value_qc["sn_score"].second, 10.0);
-    
-    // second line
-    TEST_EQUAL(mrmfqc.component_group_qcs[1].component_group_name, "componentGroup2");
-    TEST_EQUAL(mrmfqc.component_qcs[1].component_name, "component2");
-    TEST_REAL_SIMILAR(mrmfqc.component_qcs[1].meta_value_qc["sn_score"].second, 20.0);
-
-    // third line
-    TEST_EQUAL(mrmfqc.component_group_qcs[2].component_group_name, "componentGroup3");
-    TEST_EQUAL(mrmfqc.component_qcs[2].component_name, "component3");
-    TEST_REAL_SIMILAR(mrmfqc.component_qcs[2].meta_value_qc["sn_score"].second, 50.0);
-  
-  END_SECTION
-
+START_SECTION(void load(const String& filename, MRMFeatureQC& mrmfqc) const)
+{
+  MRMFeatureQCFile mrmfqcfile;
+  MRMFeatureQC mrmfqc;
+  mrmfqcfile.load(OPENMS_GET_TEST_DATA_PATH("MRMFeatureQCFile_1.csv"), mrmfqc); // components file
+  mrmfqcfile.load(OPENMS_GET_TEST_DATA_PATH("MRMFeatureQCFile_2.csv"), mrmfqc); // component groups file
+  TEST_EQUAL(mrmfqc.component_qcs[0].component_name, "component1");
+  TEST_EQUAL(mrmfqc.component_qcs[1].component_name, "component2");
+  TEST_EQUAL(mrmfqc.component_qcs[2].component_name, "component3");
+  TEST_REAL_SIMILAR(mrmfqc.component_qcs[0].meta_value_qc["sn_score"].second, 10.0);
+  TEST_REAL_SIMILAR(mrmfqc.component_qcs[1].meta_value_qc["sn_score"].second, 20.0);
+  TEST_REAL_SIMILAR(mrmfqc.component_qcs[2].meta_value_qc["sn_score"].second, 50.0);
+  TEST_EQUAL(mrmfqc.component_group_qcs[0].component_group_name, "componentGroup1");
+  TEST_EQUAL(mrmfqc.component_group_qcs[1].component_group_name, "componentGroup2");
+  TEST_EQUAL(mrmfqc.component_group_qcs[2].component_group_name, "componentGroup3");
+}
+END_SECTION
 
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////

--- a/src/tests/class_tests/openms/source/MRMFeatureQCFile_test.cpp
+++ b/src/tests/class_tests/openms/source/MRMFeatureQCFile_test.cpp
@@ -70,6 +70,36 @@ class MRMFeatureQCFile_facade : MRMFeatureQCFile
     {
       MRMFeatureQCFile::setPairValue_(key, value, boundary, meta_values_qc);
     }
+
+  Int getCastValue_(
+    const std::map<String, Size>& headers,
+    const StringList& line,
+    const String& header,
+    const Int default_value
+  ) const
+  {
+    return MRMFeatureQCFile::getCastValue_(headers, line, header, default_value);
+  }
+
+  double getCastValue_(
+    const std::map<String, Size>& headers,
+    const StringList& line,
+    const String& header,
+    const double default_value
+  ) const
+  {
+    return MRMFeatureQCFile::getCastValue_(headers, line, header, default_value);
+  }
+
+  String getCastValue_(
+    const std::map<String, Size>& headers,
+    const StringList& line,
+    const String& header,
+    const String& default_value
+  ) const
+  {
+    return MRMFeatureQCFile::getCastValue_(headers, line, header, default_value);
+  }
 };
 
 START_TEST(MRMFeatureQCFile, "$Id$")
@@ -509,6 +539,68 @@ START_SECTION(void setPairValue_(
   TEST_EQUAL(metavalues.size(), 3);
   TEST_REAL_SIMILAR(metavalues["meta3"].first, 0.0);
   TEST_REAL_SIMILAR(metavalues["meta3"].second, 0.222);
+}
+END_SECTION
+
+START_SECTION(Int getCastValue_(
+  const std::map<String, Size>& headers,
+  const StringList& line,
+  const String& header,
+  const Int default_value
+) const)
+{
+  MRMFeatureQCFile_facade mrmfqcfile_f;
+  const std::map<String, Size> headers {
+    {"component_group_name", 0},
+    {"n_heavy_l", 1},
+    {"n_heavy_u", 2}
+  };
+  const StringList line1 {"componentgroup1", "2", "3"}; // all info are present
+  const StringList line2 {"componentgroup2", "", "3"}; // some info is missing
+  TEST_EQUAL(mrmfqcfile_f.getCastValue_(headers, line1, "n_heavy_l", 3), 2) // info is found, converted and returned
+  TEST_EQUAL(mrmfqcfile_f.getCastValue_(headers, line1, "n_light_l", 4), 4) // the requested column is not present in the headers, default value is returned
+  TEST_EQUAL(mrmfqcfile_f.getCastValue_(headers, line2, "n_heavy_l", 5), 5) // the requested column is present in the headers, but the value is empty. Default value is returned
+}
+END_SECTION
+
+START_SECTION(double getCastValue_(
+  const std::map<String, Size>& headers,
+  const StringList& line,
+  const String& header,
+  const double default_value
+) const)
+{
+  MRMFeatureQCFile_facade mrmfqcfile_f;
+  const std::map<String, Size> headers {
+    {"component_name", 0},
+    {"retention_time_l", 1},
+    {"retention_time_u", 2}
+  };
+  const StringList line1 {"component1", "1.2", "1.3"}; // all info are present
+  const StringList line2 {"component2", "", "1.3"}; // some info is missing
+  TEST_EQUAL(mrmfqcfile_f.getCastValue_(headers, line1, "retention_time_l", 3.1), 1.2) // info is found, converted and returned
+  TEST_EQUAL(mrmfqcfile_f.getCastValue_(headers, line1, "intensity_l", 4.1), 4.1) // the requested column is not present in the headers, default value is returned
+  TEST_EQUAL(mrmfqcfile_f.getCastValue_(headers, line2, "retention_time_l", 5.1), 5.1) // the requested column is present in the headers, but the value is empty. Default value is returned
+}
+END_SECTION
+
+START_SECTION(String getCastValue_(
+  const std::map<String, Size>& headers,
+  const StringList& line,
+  const String& header,
+  const String& default_value
+) const)
+{
+  MRMFeatureQCFile_facade mrmfqcfile_f;
+  const std::map<String, Size> headers {
+    {"component_name", 0},
+    {"ion_ratio_feature_name", 1}
+  };
+  const StringList line1 {"component1", "name1"}; // all info are present
+  const StringList line2 {"component2", ""}; // some info is missing
+  TEST_EQUAL(mrmfqcfile_f.getCastValue_(headers, line1, "ion_ratio_feature_name", "name30"), "name1") // info is found, converted and returned
+  TEST_EQUAL(mrmfqcfile_f.getCastValue_(headers, line1, "intensity_l", "name30"), "name30") // the requested column is not present in the headers, default value is returned
+  TEST_EQUAL(mrmfqcfile_f.getCastValue_(headers, line2, "ion_ratio_feature_name", "name30"), "name30") // the requested column is present in the headers, but the value is empty. Default value is returned
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/MRMFeatureQCFile_test.cpp
+++ b/src/tests/class_tests/openms/source/MRMFeatureQCFile_test.cpp
@@ -40,6 +40,38 @@
 using namespace OpenMS;
 using namespace std;
 
+class MRMFeatureQCFile_facade : MRMFeatureQCFile
+{
+  public:
+    void pushValuesFromLine_(
+      const StringList& line,
+      const std::map<String, Size>& headers,
+      std::vector<MRMFeatureQC::ComponentQCs>& c_qcs
+    ) const
+    {
+      MRMFeatureQCFile::pushValuesFromLine_(line, headers, c_qcs);
+    }
+
+    void pushValuesFromLine_(
+      const StringList& line,
+      const std::map<String, Size>& headers,
+      std::vector<MRMFeatureQC::ComponentGroupQCs>& cg_qcs
+    ) const
+    {
+      MRMFeatureQCFile::pushValuesFromLine_(line, headers, cg_qcs);
+    }
+
+    void setPairValue_(
+      const String& key,
+      const String& value,
+      const String& boundary,
+      std::map<String, std::pair<double,double>>& meta_values_qc
+    ) const
+    {
+      MRMFeatureQCFile::setPairValue_(key, value, boundary, meta_values_qc);
+    }
+};
+
 START_TEST(MRMFeatureQCFile, "$Id$")
 
 /////////////////////////////////////////////////////////////
@@ -67,19 +99,419 @@ START_SECTION(void load(const String& filename, MRMFeatureQC& mrmfqc, const bool
   MRMFeatureQC mrmfqc;
   mrmfqcfile.load(OPENMS_GET_TEST_DATA_PATH("MRMFeatureQCFile_1.csv"), mrmfqc, false); // components file
   mrmfqcfile.load(OPENMS_GET_TEST_DATA_PATH("MRMFeatureQCFile_2.csv"), mrmfqc, true); // component groups file
-  TEST_EQUAL(mrmfqc.component_qcs[0].component_name, "component1");
-  TEST_EQUAL(mrmfqc.component_qcs[1].component_name, "component2");
-  TEST_EQUAL(mrmfqc.component_qcs[2].component_name, "component3");
-  TEST_REAL_SIMILAR(mrmfqc.component_qcs[0].meta_value_qc["sn_score"].second, 10.0);
-  TEST_REAL_SIMILAR(mrmfqc.component_qcs[1].meta_value_qc["sn_score"].second, 20.0);
-  TEST_REAL_SIMILAR(mrmfqc.component_qcs[2].meta_value_qc["sn_score"].second, 50.0);
-  TEST_EQUAL(mrmfqc.component_group_qcs[0].component_group_name, "componentGroup1");
-  TEST_EQUAL(mrmfqc.component_group_qcs[1].component_group_name, "componentGroup2");
-  TEST_EQUAL(mrmfqc.component_group_qcs[2].component_group_name, "componentGroup3");
+  const std::vector<MRMFeatureQC::ComponentQCs>& c_qcs = mrmfqc.component_qcs;
+  const std::vector<MRMFeatureQC::ComponentGroupQCs>& cg_qcs = mrmfqc.component_group_qcs;
+  TEST_EQUAL(c_qcs[0].component_name, "component1");
+  TEST_EQUAL(c_qcs[1].component_name, "component2");
+  TEST_EQUAL(c_qcs[2].component_name, "component3");
+  TEST_EQUAL(c_qcs[3].component_name, "component4"); // note that the previous line within the file is skipped because component_name is empty
+  TEST_REAL_SIMILAR(c_qcs[0].retention_time_l, 1.0);
+  TEST_REAL_SIMILAR(c_qcs[1].retention_time_l, 3.0);
+  TEST_REAL_SIMILAR(c_qcs[2].retention_time_l, 5.0);
+  TEST_REAL_SIMILAR(c_qcs[3].retention_time_l, 0.0);   // default value
+  TEST_REAL_SIMILAR(c_qcs[0].retention_time_u, 2.0);
+  TEST_REAL_SIMILAR(c_qcs[1].retention_time_u, 4.0);
+  TEST_REAL_SIMILAR(c_qcs[2].retention_time_u, 6.0);
+  TEST_REAL_SIMILAR(c_qcs[3].retention_time_u, 100.0); // default value
+  TEST_REAL_SIMILAR(c_qcs[0].intensity_l, 1000.0);
+  TEST_REAL_SIMILAR(c_qcs[1].intensity_l, 2000.0);
+  TEST_REAL_SIMILAR(c_qcs[2].intensity_l, 3000.0);
+  TEST_REAL_SIMILAR(c_qcs[3].intensity_l, 0.0);        // default value
+  TEST_REAL_SIMILAR(c_qcs[0].intensity_u, 1000000.0);
+  TEST_REAL_SIMILAR(c_qcs[1].intensity_u, 2000000.0);
+  TEST_REAL_SIMILAR(c_qcs[2].intensity_u, 3000000.0);
+  TEST_REAL_SIMILAR(c_qcs[3].intensity_u, 1e12);       // default value
+  TEST_REAL_SIMILAR(c_qcs[0].overall_quality_l, 2.0);
+  TEST_REAL_SIMILAR(c_qcs[1].overall_quality_l, 3.0);
+  TEST_REAL_SIMILAR(c_qcs[2].overall_quality_l, 4.0);
+  TEST_REAL_SIMILAR(c_qcs[3].overall_quality_l, 0.0);  // default value
+  TEST_REAL_SIMILAR(c_qcs[0].overall_quality_u, 5.0);
+  TEST_REAL_SIMILAR(c_qcs[1].overall_quality_u, 6.0);
+  TEST_REAL_SIMILAR(c_qcs[2].overall_quality_u, 7.0);
+  TEST_REAL_SIMILAR(c_qcs[3].overall_quality_u, 1e12); // default value
+  TEST_REAL_SIMILAR(c_qcs[0].meta_value_qc.at("peak_apex_int").first, 1000.0);
+  TEST_REAL_SIMILAR(c_qcs[1].meta_value_qc.at("peak_apex_int").first, 2000.0);
+  TEST_REAL_SIMILAR(c_qcs[2].meta_value_qc.at("peak_apex_int").first, 3000.0);
+  TEST_REAL_SIMILAR(c_qcs[3].meta_value_qc.at("peak_apex_int").first, 0.0);        // default value
+  TEST_REAL_SIMILAR(c_qcs[0].meta_value_qc.at("peak_apex_int").second, 1000000.0);
+  TEST_REAL_SIMILAR(c_qcs[1].meta_value_qc.at("peak_apex_int").second, 2000000.0);
+  TEST_REAL_SIMILAR(c_qcs[2].meta_value_qc.at("peak_apex_int").second, 3000000.0);
+  TEST_REAL_SIMILAR(c_qcs[3].meta_value_qc.at("peak_apex_int").second, 1e12);      // default value
+  TEST_REAL_SIMILAR(c_qcs[0].meta_value_qc.at("sn_score").first, 2.0);
+  TEST_REAL_SIMILAR(c_qcs[1].meta_value_qc.at("sn_score").first, 5.0);
+  TEST_REAL_SIMILAR(c_qcs[2].meta_value_qc.at("sn_score").first, 10.0);
+  TEST_REAL_SIMILAR(c_qcs[3].meta_value_qc.at("sn_score").first, 0.0);             // default value
+  TEST_REAL_SIMILAR(c_qcs[0].meta_value_qc.at("sn_score").second, 10.0);
+  TEST_REAL_SIMILAR(c_qcs[1].meta_value_qc.at("sn_score").second, 20.0);
+  TEST_REAL_SIMILAR(c_qcs[2].meta_value_qc.at("sn_score").second, 50.0);
+  TEST_REAL_SIMILAR(c_qcs[3].meta_value_qc.at("sn_score").second, 1e12);           // default value
+  TEST_EQUAL(cg_qcs[0].component_group_name, "componentGroup1");
+  TEST_EQUAL(cg_qcs[1].component_group_name, "componentGroup2");
+  TEST_EQUAL(cg_qcs[2].component_group_name, "componentGroup3");
+  TEST_EQUAL(cg_qcs[3].component_group_name, "componentGroup5");
+  TEST_EQUAL(cg_qcs[0].n_heavy_l, 1);
+  TEST_EQUAL(cg_qcs[2].n_heavy_l, 3);
+  TEST_EQUAL(cg_qcs[0].n_heavy_u, 2);
+  TEST_EQUAL(cg_qcs[2].n_heavy_u, 4);
+  TEST_EQUAL(cg_qcs[0].n_light_l, 3);
+  TEST_EQUAL(cg_qcs[2].n_light_l, 5);
+  TEST_EQUAL(cg_qcs[0].n_light_u, 4);
+  TEST_EQUAL(cg_qcs[2].n_light_u, 6);
+  TEST_EQUAL(cg_qcs[0].n_detecting_l, 5);
+  TEST_EQUAL(cg_qcs[2].n_detecting_l, 7);
+  TEST_EQUAL(cg_qcs[0].n_detecting_u, 6);
+  TEST_EQUAL(cg_qcs[2].n_detecting_u, 8);
+  TEST_EQUAL(cg_qcs[0].n_quantifying_l, 7);
+  TEST_EQUAL(cg_qcs[2].n_quantifying_l, 9);
+  TEST_EQUAL(cg_qcs[0].n_quantifying_u, 8);
+  TEST_EQUAL(cg_qcs[2].n_quantifying_u, 10);
+  TEST_EQUAL(cg_qcs[0].n_identifying_l, 9);
+  TEST_EQUAL(cg_qcs[2].n_identifying_l, 11);
+  TEST_EQUAL(cg_qcs[0].n_identifying_u, 10);
+  TEST_EQUAL(cg_qcs[2].n_identifying_u, 12);
+  TEST_EQUAL(cg_qcs[0].n_transitions_l, 11);
+  TEST_EQUAL(cg_qcs[2].n_transitions_l, 13);
+  TEST_EQUAL(cg_qcs[0].n_transitions_u, 12);
+  TEST_EQUAL(cg_qcs[2].n_transitions_u, 14);
+  TEST_EQUAL(cg_qcs[0].ion_ratio_pair_name_1, "component1");
+  TEST_EQUAL(cg_qcs[2].ion_ratio_pair_name_1, "component5");
+  TEST_EQUAL(cg_qcs[0].ion_ratio_pair_name_2, "component2");
+  TEST_EQUAL(cg_qcs[2].ion_ratio_pair_name_2, "component6");
+  TEST_REAL_SIMILAR(cg_qcs[0].ion_ratio_l, 0.5);
+  TEST_REAL_SIMILAR(cg_qcs[2].ion_ratio_l, 2.5);
+  TEST_REAL_SIMILAR(cg_qcs[0].ion_ratio_u, 0.6);
+  TEST_REAL_SIMILAR(cg_qcs[2].ion_ratio_u, 2.6);
+  TEST_EQUAL(cg_qcs[0].ion_ratio_feature_name, "feature1");
+  TEST_EQUAL(cg_qcs[2].ion_ratio_feature_name, "feature3");
+  TEST_REAL_SIMILAR(cg_qcs[0].retention_time_l, 1.0);
+  TEST_REAL_SIMILAR(cg_qcs[1].retention_time_l, 2.0);
+  TEST_REAL_SIMILAR(cg_qcs[2].retention_time_l, 3.0);
+  TEST_REAL_SIMILAR(cg_qcs[0].retention_time_u, 2.0);
+  TEST_REAL_SIMILAR(cg_qcs[1].retention_time_u, 3.0);
+  TEST_REAL_SIMILAR(cg_qcs[2].retention_time_u, 4.0);
+  TEST_REAL_SIMILAR(cg_qcs[0].intensity_l, 1000.0);
+  TEST_REAL_SIMILAR(cg_qcs[1].intensity_l, 1001.0);
+  TEST_REAL_SIMILAR(cg_qcs[2].intensity_l, 1002.0);
+  TEST_REAL_SIMILAR(cg_qcs[0].intensity_u, 1000000.0);
+  TEST_REAL_SIMILAR(cg_qcs[1].intensity_u, 1000001.0);
+  TEST_REAL_SIMILAR(cg_qcs[2].intensity_u, 1000002.0);
+  TEST_REAL_SIMILAR(cg_qcs[0].overall_quality_l, 2.0);
+  TEST_REAL_SIMILAR(cg_qcs[1].overall_quality_l, 3.0);
+  TEST_REAL_SIMILAR(cg_qcs[2].overall_quality_l, 4.0);
+  TEST_REAL_SIMILAR(cg_qcs[0].overall_quality_u, 5.0);
+  TEST_REAL_SIMILAR(cg_qcs[1].overall_quality_u, 6.0);
+  TEST_REAL_SIMILAR(cg_qcs[2].overall_quality_u, 7.0);
+  TEST_REAL_SIMILAR(cg_qcs[0].meta_value_qc.at("peak_apex_int").first, 1000.0);
+  TEST_REAL_SIMILAR(cg_qcs[2].meta_value_qc.at("peak_apex_int").first, 1002.0);
+  TEST_REAL_SIMILAR(cg_qcs[0].meta_value_qc.at("peak_apex_int").second, 1000000.0);
+  TEST_REAL_SIMILAR(cg_qcs[2].meta_value_qc.at("peak_apex_int").second, 1000002.0);
+  TEST_REAL_SIMILAR(cg_qcs[0].meta_value_qc.at("sn_score").first, 2.0);
+  TEST_REAL_SIMILAR(cg_qcs[2].meta_value_qc.at("sn_score").first, 10.0);
+  TEST_REAL_SIMILAR(cg_qcs[0].meta_value_qc.at("sn_score").second, 10.0);
+  TEST_REAL_SIMILAR(cg_qcs[2].meta_value_qc.at("sn_score").second, 50.0);
+  TEST_EQUAL(cg_qcs[3].component_group_name, "componentGroup5");
+  TEST_EQUAL(cg_qcs[3].n_heavy_l, 0);
+  TEST_EQUAL(cg_qcs[3].n_heavy_u, 100);
+  TEST_EQUAL(cg_qcs[3].n_light_l, 0);
+  TEST_EQUAL(cg_qcs[3].n_light_u, 100);
+  TEST_EQUAL(cg_qcs[3].n_detecting_l, 0);
+  TEST_EQUAL(cg_qcs[3].n_detecting_u, 100);
+  TEST_EQUAL(cg_qcs[3].n_quantifying_l, 0);
+  TEST_EQUAL(cg_qcs[3].n_quantifying_u, 100);
+  TEST_EQUAL(cg_qcs[3].n_identifying_l, 0);
+  TEST_EQUAL(cg_qcs[3].n_identifying_u, 100);
+  TEST_EQUAL(cg_qcs[3].n_transitions_l, 0);
+  TEST_EQUAL(cg_qcs[3].n_transitions_u, 100);
+  TEST_EQUAL(cg_qcs[3].ion_ratio_pair_name_1, "");
+  TEST_EQUAL(cg_qcs[3].ion_ratio_pair_name_2, "");
+  TEST_REAL_SIMILAR(cg_qcs[3].ion_ratio_l, 0.0);
+  TEST_REAL_SIMILAR(cg_qcs[3].ion_ratio_u, 1e12);
+  TEST_EQUAL(cg_qcs[3].ion_ratio_feature_name, "");
+  TEST_REAL_SIMILAR(cg_qcs[3].retention_time_l, 0.0);
+  TEST_REAL_SIMILAR(cg_qcs[3].retention_time_u, 100.0);
+  TEST_REAL_SIMILAR(cg_qcs[3].intensity_l, 0.0);
+  TEST_REAL_SIMILAR(cg_qcs[3].intensity_u, 1e12);
+  TEST_REAL_SIMILAR(cg_qcs[3].overall_quality_l, 0.0);
+  TEST_REAL_SIMILAR(cg_qcs[3].overall_quality_u, 1e12);
+  TEST_REAL_SIMILAR(cg_qcs[3].meta_value_qc.at("peak_apex_int").first, 0.0);
+  TEST_REAL_SIMILAR(cg_qcs[3].meta_value_qc.at("peak_apex_int").second, 1e12);
+  TEST_REAL_SIMILAR(cg_qcs[3].meta_value_qc.at("sn_score").first, 0.0);
+  TEST_REAL_SIMILAR(cg_qcs[3].meta_value_qc.at("sn_score").second, 1e12);
+}
+END_SECTION
+
+START_SECTION(void pushValuesFromLine_(
+  const StringList& line,
+  const std::map<String, Size>& headers,
+  std::vector<MRMFeatureQC::ComponentQCs>& c_qcs
+) const)
+{
+  const std::map<String, Size> headers {
+    {"component_name", 0},
+    {"retention_time_l", 1},
+    {"retention_time_u", 2},
+    {"intensity_l", 3},
+    {"intensity_u", 4},
+    {"overall_quality_l", 5},
+    {"overall_quality_u", 6},
+    {"metaValue_peak_apex_int_l", 7},
+    {"metaValue_peak_apex_int_u", 8},
+    {"metaValue_sn_score_l", 9},
+    {"metaValue_sn_score_u", 10}
+  };
+
+  const std::vector<String> sl1 { // all info are present
+    "component1",
+    "0.1", "0.2",
+    "0.3", "0.4",
+    "0.5", "0.6",
+    "0.7", "0.8",
+    "0.9", "1.0"
+  };
+
+  const std::vector<String> sl2 { // component_name is empty
+    "",
+    "0.1", "0.2",
+    "0.3", "0.4",
+    "0.5", "0.6",
+    "0.7", "0.8",
+    "0.9", "1.0"
+  };
+
+  const std::vector<String> sl3 { // testing defaults
+    "component3",
+    "", "",
+    "", "",
+    "", "",
+    "", "",
+    "", ""
+  };
+
+  MRMFeatureQCFile_facade mrmfqcfile_f;
+  std::vector<MRMFeatureQC::ComponentQCs> c_qcs;
+
+  mrmfqcfile_f.pushValuesFromLine_(sl1, headers, c_qcs);
+  TEST_EQUAL(c_qcs.size(), 1);
+  TEST_EQUAL(c_qcs[0].component_name, "component1");
+  TEST_REAL_SIMILAR(c_qcs[0].retention_time_l, 0.1);
+  TEST_REAL_SIMILAR(c_qcs[0].retention_time_u, 0.2);
+  TEST_REAL_SIMILAR(c_qcs[0].intensity_l, 0.3);
+  TEST_REAL_SIMILAR(c_qcs[0].intensity_u, 0.4);
+  TEST_REAL_SIMILAR(c_qcs[0].overall_quality_l, 0.5);
+  TEST_REAL_SIMILAR(c_qcs[0].overall_quality_u, 0.6);
+  TEST_REAL_SIMILAR(c_qcs[0].meta_value_qc["peak_apex_int"].first, 0.7);
+  TEST_REAL_SIMILAR(c_qcs[0].meta_value_qc["peak_apex_int"].second, 0.8);
+  TEST_REAL_SIMILAR(c_qcs[0].meta_value_qc["sn_score"].first, 0.9);
+  TEST_REAL_SIMILAR(c_qcs[0].meta_value_qc["sn_score"].second, 1.0);
+  mrmfqcfile_f.pushValuesFromLine_(sl2, headers, c_qcs);
+  TEST_EQUAL(c_qcs.size(), 1);
+  mrmfqcfile_f.pushValuesFromLine_(sl3, headers, c_qcs);
+  TEST_EQUAL(c_qcs.size(), 2);
+  TEST_EQUAL(c_qcs[1].component_name, "component3");
+  TEST_REAL_SIMILAR(c_qcs[1].retention_time_l, 0.0);
+  TEST_REAL_SIMILAR(c_qcs[1].retention_time_u, 100.0);
+  TEST_REAL_SIMILAR(c_qcs[1].intensity_l, 0.0);
+  TEST_REAL_SIMILAR(c_qcs[1].intensity_u, 1e12);
+  TEST_REAL_SIMILAR(c_qcs[1].overall_quality_l, 0.0);
+  TEST_REAL_SIMILAR(c_qcs[1].overall_quality_u, 1e12);
+  TEST_REAL_SIMILAR(c_qcs[1].meta_value_qc["peak_apex_int"].first, 0.0);
+  TEST_REAL_SIMILAR(c_qcs[1].meta_value_qc["peak_apex_int"].second, 1e12);
+  TEST_REAL_SIMILAR(c_qcs[1].meta_value_qc["sn_score"].first, 0.0);
+  TEST_REAL_SIMILAR(c_qcs[1].meta_value_qc["sn_score"].second, 1e12);
+}
+END_SECTION
+
+START_SECTION(void pushValuesFromLine_(
+  const StringList& line,
+  const std::map<String, Size>& headers,
+  std::vector<MRMFeatureQC::ComponentGroupQCs>& cg_qcs
+) const)
+{
+  const std::map<String, Size> headers {
+    {"component_group_name", 0},
+    {"n_heavy_l", 1},
+    {"n_heavy_u", 2},
+    {"n_light_l", 3},
+    {"n_light_u", 4},
+    {"n_detecting_l", 5},
+    {"n_detecting_u", 6},
+    {"n_quantifying_l", 7},
+    {"n_quantifying_u", 8},
+    {"n_identifying_l", 9},
+    {"n_identifying_u", 10},
+    {"n_transitions_l", 11},
+    {"n_transitions_u", 12},
+    {"ion_ratio_pair_name_1", 13},
+    {"ion_ratio_pair_name_2", 14},
+    {"ion_ratio_l", 15},
+    {"ion_ratio_u", 16},
+    {"ion_ratio_feature_name", 17},
+    {"retention_time_l", 18},
+    {"retention_time_u", 19},
+    {"intensity_l", 20},
+    {"intensity_u", 21},
+    {"overall_quality_l", 22},
+    {"overall_quality_u", 23},
+    {"metaValue_peak_apex_int_l", 24},
+    {"metaValue_peak_apex_int_u", 25},
+    {"metaValue_sn_score_l", 26},
+    {"metaValue_sn_score_u", 27}
+  };
+
+  const std::vector<String> sl1 { // all info are present
+    "component_group_1",
+    "1", "2",
+    "3", "4",
+    "5", "6",
+    "7", "8",
+    "9", "10",
+    "11", "12",
+    "ionRatioPairName1", "ionRatioPairName2",
+    "1.1", "1.2",
+    "ionRatioFeatureName",
+    "0.1", "0.2",
+    "0.3", "0.4",
+    "0.5", "0.6",
+    "0.7", "0.8",
+    "0.9", "1.0"
+  };
+
+  const std::vector<String> sl2 { // component_name is empty
+    "",
+    "1", "2",
+    "3", "4",
+    "5", "6",
+    "7", "8",
+    "9", "10",
+    "11", "12",
+    "ionRatioPairName1", "ionRatioPairName2",
+    "1.1", "1.2",
+    "ionRatioFeatureName",
+    "0.1", "0.2",
+    "0.3", "0.4",
+    "0.5", "0.6",
+    "0.7", "0.8",
+    "0.9", "1.0"
+  };
+
+  const std::vector<String> sl3 { // testing defaults
+    "component_group_3",
+    "", "",
+    "", "",
+    "", "",
+    "", "",
+    "", "",
+    "", "",
+    "", "",
+    "", "",
+    "",
+    "", "",
+    "", "",
+    "", "",
+    "", "",
+    "", ""
+  };
+
+  MRMFeatureQCFile_facade mrmfqcfile_f;
+  std::vector<MRMFeatureQC::ComponentGroupQCs> cg_qcs;
+
+  mrmfqcfile_f.pushValuesFromLine_(sl1, headers, cg_qcs);
+  TEST_EQUAL(cg_qcs.size(), 1);
+  TEST_EQUAL(cg_qcs[0].component_group_name, "component_group_1");
+  TEST_EQUAL(cg_qcs[0].n_heavy_l, 1);
+  TEST_EQUAL(cg_qcs[0].n_heavy_u, 2);
+  TEST_EQUAL(cg_qcs[0].n_light_l, 3);
+  TEST_EQUAL(cg_qcs[0].n_light_u, 4);
+  TEST_EQUAL(cg_qcs[0].n_detecting_l, 5);
+  TEST_EQUAL(cg_qcs[0].n_detecting_u, 6);
+  TEST_EQUAL(cg_qcs[0].n_quantifying_l, 7);
+  TEST_EQUAL(cg_qcs[0].n_quantifying_u, 8);
+  TEST_EQUAL(cg_qcs[0].n_identifying_l, 9);
+  TEST_EQUAL(cg_qcs[0].n_identifying_u, 10);
+  TEST_EQUAL(cg_qcs[0].n_transitions_l, 11);
+  TEST_EQUAL(cg_qcs[0].n_transitions_u, 12);
+  TEST_EQUAL(cg_qcs[0].ion_ratio_pair_name_1, "ionRatioPairName1");
+  TEST_EQUAL(cg_qcs[0].ion_ratio_pair_name_2, "ionRatioPairName2");
+  TEST_REAL_SIMILAR(cg_qcs[0].ion_ratio_l, 1.1);
+  TEST_REAL_SIMILAR(cg_qcs[0].ion_ratio_u, 1.2);
+  TEST_EQUAL(cg_qcs[0].ion_ratio_feature_name, "ionRatioFeatureName");
+  TEST_REAL_SIMILAR(cg_qcs[0].retention_time_l, 0.1);
+  TEST_REAL_SIMILAR(cg_qcs[0].retention_time_u, 0.2);
+  TEST_REAL_SIMILAR(cg_qcs[0].intensity_l, 0.3);
+  TEST_REAL_SIMILAR(cg_qcs[0].intensity_u, 0.4);
+  TEST_REAL_SIMILAR(cg_qcs[0].overall_quality_l, 0.5);
+  TEST_REAL_SIMILAR(cg_qcs[0].overall_quality_u, 0.6);
+  TEST_REAL_SIMILAR(cg_qcs[0].meta_value_qc["peak_apex_int"].first, 0.7);
+  TEST_REAL_SIMILAR(cg_qcs[0].meta_value_qc["peak_apex_int"].second, 0.8);
+  TEST_REAL_SIMILAR(cg_qcs[0].meta_value_qc["sn_score"].first, 0.9);
+  TEST_REAL_SIMILAR(cg_qcs[0].meta_value_qc["sn_score"].second, 1.0);
+  mrmfqcfile_f.pushValuesFromLine_(sl2, headers, cg_qcs);
+  TEST_EQUAL(cg_qcs.size(), 1);
+  mrmfqcfile_f.pushValuesFromLine_(sl3, headers, cg_qcs);
+  TEST_EQUAL(cg_qcs.size(), 2);
+  TEST_EQUAL(cg_qcs[1].component_group_name, "component_group_3");
+  TEST_EQUAL(cg_qcs[1].n_heavy_l, 0);
+  TEST_EQUAL(cg_qcs[1].n_heavy_u, 100);
+  TEST_EQUAL(cg_qcs[1].n_light_l, 0);
+  TEST_EQUAL(cg_qcs[1].n_light_u, 100);
+  TEST_EQUAL(cg_qcs[1].n_detecting_l, 0);
+  TEST_EQUAL(cg_qcs[1].n_detecting_u, 100);
+  TEST_EQUAL(cg_qcs[1].n_quantifying_l, 0);
+  TEST_EQUAL(cg_qcs[1].n_quantifying_u, 100);
+  TEST_EQUAL(cg_qcs[1].n_identifying_l, 0);
+  TEST_EQUAL(cg_qcs[1].n_identifying_u, 100);
+  TEST_EQUAL(cg_qcs[1].n_transitions_l, 0);
+  TEST_EQUAL(cg_qcs[1].n_transitions_u, 100);
+  TEST_EQUAL(cg_qcs[1].ion_ratio_pair_name_1, "");
+  TEST_EQUAL(cg_qcs[1].ion_ratio_pair_name_2, "");
+  TEST_REAL_SIMILAR(cg_qcs[1].ion_ratio_l, 0.0);
+  TEST_REAL_SIMILAR(cg_qcs[1].ion_ratio_u, 1e12);
+  TEST_EQUAL(cg_qcs[1].ion_ratio_feature_name, "");
+  TEST_REAL_SIMILAR(cg_qcs[1].retention_time_l, 0.0);
+  TEST_REAL_SIMILAR(cg_qcs[1].retention_time_u, 100.0);
+  TEST_REAL_SIMILAR(cg_qcs[1].intensity_l, 0.0);
+  TEST_REAL_SIMILAR(cg_qcs[1].intensity_u, 1e12);
+  TEST_REAL_SIMILAR(cg_qcs[1].overall_quality_l, 0.0);
+  TEST_REAL_SIMILAR(cg_qcs[1].overall_quality_u, 1e12);
+  TEST_REAL_SIMILAR(cg_qcs[1].meta_value_qc["peak_apex_int"].first, 0.0);
+  TEST_REAL_SIMILAR(cg_qcs[1].meta_value_qc["peak_apex_int"].second, 1e12);
+  TEST_REAL_SIMILAR(cg_qcs[1].meta_value_qc["sn_score"].first, 0.0);
+  TEST_REAL_SIMILAR(cg_qcs[1].meta_value_qc["sn_score"].second, 1e12);
+}
+END_SECTION
+
+START_SECTION(void setPairValue_(
+  const String& key,
+  const String& value,
+  const String& boundary,
+  std::map<String, std::pair<double,double>>& meta_values_qc
+) const)
+{
+  std::map<String, std::pair<double,double>> metavalues;
+  MRMFeatureQCFile_facade mrmfqcfile_f;
+  mrmfqcfile_f.setPairValue_("meta1", "0.123", "u", metavalues); // first pair (initializing the upper bound)
+  TEST_EQUAL(metavalues.size(), 1);
+  TEST_REAL_SIMILAR(metavalues["meta1"].first, 0.0);             // default lower bound value
+  TEST_REAL_SIMILAR(metavalues["meta1"].second, 0.123);
+  mrmfqcfile_f.setPairValue_("meta1", "0.456", "l", metavalues); // overwrite the lower bound value
+  TEST_EQUAL(metavalues.size(), 1);                              // the size of the map doesn't change
+  TEST_REAL_SIMILAR(metavalues["meta1"].first, 0.456);
+  TEST_REAL_SIMILAR(metavalues["meta1"].second, 0.123);
+  mrmfqcfile_f.setPairValue_("meta1", "0.789", "u", metavalues); // overwrite the upper bound value
+  TEST_EQUAL(metavalues.size(), 1);
+  TEST_REAL_SIMILAR(metavalues["meta1"].first, 0.456);
+  TEST_REAL_SIMILAR(metavalues["meta1"].second, 0.789);
+  mrmfqcfile_f.setPairValue_("meta2", "0.111", "l", metavalues); // create another pair (initializing the lower bound)
+  TEST_EQUAL(metavalues.size(), 2);                              // the size of the map changes
+  TEST_REAL_SIMILAR(metavalues["meta2"].first, 0.111);
+  TEST_REAL_SIMILAR(metavalues["meta2"].second, 1e12);           // default upper bound value
+  mrmfqcfile_f.setPairValue_("meta3", "0.222", "u", metavalues); // just another pair
+  TEST_EQUAL(metavalues.size(), 3);
+  TEST_REAL_SIMILAR(metavalues["meta3"].first, 0.0);
+  TEST_REAL_SIMILAR(metavalues["meta3"].second, 0.222);
 }
 END_SECTION
 
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 END_TEST
-

--- a/src/tests/class_tests/openms/source/MRMFeatureQCFile_test.cpp
+++ b/src/tests/class_tests/openms/source/MRMFeatureQCFile_test.cpp
@@ -61,12 +61,12 @@ START_SECTION(~MRMFeatureQCFile())
 }
 END_SECTION
 
-START_SECTION(void load(const String& filename, MRMFeatureQC& mrmfqc) const)
+START_SECTION(void load(const String& filename, MRMFeatureQC& mrmfqc, const bool is_component_group) const)
 {
   MRMFeatureQCFile mrmfqcfile;
   MRMFeatureQC mrmfqc;
-  mrmfqcfile.load(OPENMS_GET_TEST_DATA_PATH("MRMFeatureQCFile_1.csv"), mrmfqc); // components file
-  mrmfqcfile.load(OPENMS_GET_TEST_DATA_PATH("MRMFeatureQCFile_2.csv"), mrmfqc); // component groups file
+  mrmfqcfile.load(OPENMS_GET_TEST_DATA_PATH("MRMFeatureQCFile_1.csv"), mrmfqc, false); // components file
+  mrmfqcfile.load(OPENMS_GET_TEST_DATA_PATH("MRMFeatureQCFile_2.csv"), mrmfqc, true); // component groups file
   TEST_EQUAL(mrmfqc.component_qcs[0].component_name, "component1");
   TEST_EQUAL(mrmfqc.component_qcs[1].component_name, "component2");
   TEST_EQUAL(mrmfqc.component_qcs[2].component_name, "component3");


### PR DESCRIPTION
@dmccloskey Documentation is missing, but it should already give you the possibility to load and use your files.

The `load()` method automatically recognizes if it is dealing with a component file or component groups file. The interfaces has not changed.

The metavalues member has been added to the component groups structure, as well as rt, intensity and overall quality members.

You can check the updated tests to see how it's used.