### PR TITLE
Refactor/mrm transition group picker no consensus boundaries

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMTransitionGroupPicker.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMTransitionGroupPicker.h
@@ -333,9 +333,10 @@ public:
 
         SpectrumT used_chromatogram;
         // resample the current chromatogram
+        // TODO: need to ensure that our master container is larger than local_left / local_right
         if (peak_integration_ == "original")
         {
-          used_chromatogram = resampleChromatogram_(chromatogram, master_peak_container, best_left, best_right);
+          used_chromatogram = resampleChromatogram_(chromatogram, master_peak_container, local_left, local_right);
           // const SpectrumT& used_chromatogram = chromatogram; // instead of resampling
         }
         else if (peak_integration_ == "smoothed" && smoothed_chroms.size() <= k)
@@ -345,7 +346,7 @@ public:
         }        
         else if (peak_integration_ == "smoothed")
         {
-          used_chromatogram = resampleChromatogram_(smoothed_chroms[k], master_peak_container, best_left, best_right);
+          used_chromatogram = resampleChromatogram_(smoothed_chroms[k], master_peak_container, local_left, local_right);
         }
         else
         {
@@ -358,7 +359,7 @@ public:
         f.setQuality(0, quality);
         f.setOverallQuality(quality);
 
-        PeakIntegrator::PeakArea pa = pi_.integratePeak(used_chromatogram, best_left, best_right);
+        PeakIntegrator::PeakArea pa = pi_.integratePeak(used_chromatogram, local_left, local_right);
         double peak_integral = pa.area;
         double peak_apex_int = pa.height;
         f.setMetaValue("peak_apex_position", pa.apex_pos);
@@ -373,15 +374,15 @@ public:
           }
           else if (background_subtraction_ == "original")
           {
-            const double intensity_left = chromatogram.PosBegin(best_left)->getIntensity();
-            const double intensity_right = (chromatogram.PosEnd(best_right) - 1)->getIntensity();
-            const UInt n_points = std::distance(chromatogram.PosBegin(best_left), chromatogram.PosEnd(best_right));
+            const double intensity_left = chromatogram.PosBegin(local_left)->getIntensity();
+            const double intensity_right = (chromatogram.PosEnd(local_right) - 1)->getIntensity();
+            const UInt n_points = std::distance(chromatogram.PosBegin(local_left), chromatogram.PosEnd(local_right));
             avg_noise_level = (intensity_right + intensity_left) / 2;
             background = avg_noise_level * n_points;
           }
           else if (background_subtraction_ == "exact")
           {
-            PeakIntegrator::PeakBackground pb = pi_.estimateBackground(used_chromatogram, best_left, best_right, pa.apex_pos);
+            PeakIntegrator::PeakBackground pb = pi_.estimateBackground(used_chromatogram, local_left, local_right, pa.apex_pos);
             background = pb.area;
             avg_noise_level = pb.height;
           }
@@ -421,7 +422,7 @@ public:
         // Calculate peak shape metrics that will be used for later QC
         if (compute_peak_shape_metrics_)
         {
-          PeakIntegrator::PeakShapeMetrics psm = pi_.calculatePeakShapeMetrics(used_chromatogram, best_left, best_right, peak_apex_int, pa.apex_pos);
+          PeakIntegrator::PeakShapeMetrics psm = pi_.calculatePeakShapeMetrics(used_chromatogram, local_left, local_right, peak_apex_int, pa.apex_pos);
           f.setMetaValue("width_at_5", psm.width_at_5);
           f.setMetaValue("width_at_10", psm.width_at_10);
           f.setMetaValue("width_at_50", psm.width_at_50);
@@ -462,7 +463,7 @@ public:
         // resample the current chromatogram
         if (peak_integration_ == "original")
         {
-          used_chromatogram = resampleChromatogram_(chromatogram, master_peak_container, best_left, best_right);
+          used_chromatogram = resampleChromatogram_(chromatogram, master_peak_container, local_left, local_right);
           // const SpectrumT& used_chromatogram = chromatogram; // instead of resampling
         }
         else if (peak_integration_ == "smoothed" && smoothed_chroms.size() <= prec_idx)
@@ -472,7 +473,7 @@ public:
         }
         else if (peak_integration_ == "smoothed")
         {
-          used_chromatogram = resampleChromatogram_(smoothed_chroms[prec_idx], master_peak_container, best_left, best_right);
+          used_chromatogram = resampleChromatogram_(smoothed_chroms[prec_idx], master_peak_container, local_left, local_right);
         }
         else
         {
@@ -485,7 +486,7 @@ public:
         f.setQuality(0, quality);
         f.setOverallQuality(quality);
 
-        PeakIntegrator::PeakArea pa = pi_.integratePeak(used_chromatogram, best_left, best_right);
+        PeakIntegrator::PeakArea pa = pi_.integratePeak(used_chromatogram, local_left, local_right);
         double peak_integral = pa.area;
         double peak_apex_int = pa.height;
 
@@ -500,15 +501,15 @@ public:
           }
           else if (background_subtraction_ == "original")
           {
-            const double intensity_left = chromatogram.PosBegin(best_left)->getIntensity();
-            const double intensity_right = (chromatogram.PosEnd(best_right) - 1)->getIntensity();
-            const UInt n_points = std::distance(chromatogram.PosBegin(best_left), chromatogram.PosEnd(best_right));
+            const double intensity_left = chromatogram.PosBegin(local_left)->getIntensity();
+            const double intensity_right = (chromatogram.PosEnd(local_right) - 1)->getIntensity();
+            const UInt n_points = std::distance(chromatogram.PosBegin(local_left), chromatogram.PosEnd(local_right));
             avg_noise_level = (intensity_right + intensity_left) / 2;
             background = avg_noise_level * n_points;
           }
           else if (background_subtraction_ == "exact")
           {
-            PeakIntegrator::PeakBackground pb = pi_.estimateBackground(used_chromatogram, best_left, best_right, pa.apex_pos);
+            PeakIntegrator::PeakBackground pb = pi_.estimateBackground(used_chromatogram, local_left, local_right, pa.apex_pos);
             background = pb.area;
             avg_noise_level = pb.height;
           }

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMTransitionGroupPicker.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMTransitionGroupPicker.h
@@ -255,13 +255,13 @@ public:
       {
         // Pick the most intense peak for each chromatogram and use this for
         // the current peak. Note that we will only set the most intense peak
-        // to zero, so if there are two peaks for some transitions, we will get
-        // to them later.
+        // per chromatogram to zero, so if there are two peaks for some transitions, we will get
+        // to them later. If there is no peak, then we transfer transition boundaries from "master" peak.
         {
           for (Size k = 0; k < picked_chroms.size(); k++)
           {
             double intensity(-1);
-            double maxi = 0;
+            int maxi = -1;
             for (Size i = 0; i < picked_chroms[k].size(); i++)
             {
               if (picked_chroms[k][i].getMZ() >= best_left && picked_chroms[k][i].getMZ() <= best_right)
@@ -269,13 +269,21 @@ public:
                 if (picked_chroms[k][i].getIntensity() >= intensity)
                 {
                   intensity = picked_chroms[k][i].getIntensity();
-                  maxi = i;
+                  maxi = (int)i;
                 }
               }
             }
-            double l = picked_chroms[k].getFloatDataArrays()[1][maxi];
-            double r = picked_chroms[k].getFloatDataArrays()[2][maxi];
-            picked_chroms[k][maxi].setIntensity(0.0); // only remove one peak per transition
+            
+            // Select master peak boundaries, or in the case we found at least one peak, the local peak boundaries 
+            double l = best_left;
+            double r = best_right;
+            if (maxi >= 0)
+            {
+              double l = picked_chroms[k].getFloatDataArrays()[1][maxi];
+              double r = picked_chroms[k].getFloatDataArrays()[2][maxi];
+              picked_chroms[k][maxi].setIntensity(0.0); // only remove one peak per transition
+            }
+            
             left_edges.push_back(l);
             right_edges.push_back(r);
             // ensure we remember the overall maxima / minima

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMTransitionGroupPicker.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMTransitionGroupPicker.h
@@ -261,7 +261,7 @@ public:
           for (Size k = 0; k < picked_chroms.size(); k++)
           {
             double intensity(-1);
-            double maxi;
+            double maxi = 0;
             for (Size i = 0; i < picked_chroms[k].size(); i++)
             {
               if (picked_chroms[k][i].getMZ() >= best_left && picked_chroms[k][i].getMZ() <= best_right)

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMTransitionGroupPicker.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMTransitionGroupPicker.cpp
@@ -60,11 +60,14 @@ namespace OpenMS
     defaults_.setValue("background_subtraction", "none", "Remove background from peak signal using estimated noise levels. The 'original' method is only provided for historical purposes, please use the 'exact' method and set parameters using the PeakIntegrator: settings. The same original or smoothed chromatogram specified by peak_integration will be used for background estimation.", ListUtils::create<String>("advanced"));
     defaults_.setValidStrings("background_subtraction", ListUtils::create<String>("none,original,exact"));
 
-    defaults_.setValue("recalculate_peaks", "false", "Tries to get better peak picking by looking at peak consistency of all picked peaks. Tries to use the consensus (median) peak border if theof variation within the picked peaks is too large.", ListUtils::create<String>("advanced"));
+    defaults_.setValue("recalculate_peaks", "false", "Tries to get better peak picking by looking at peak consistency of all picked peaks. Tries to use the consensus (median) peak border if the variation within the picked peaks is too large.", ListUtils::create<String>("advanced"));
     defaults_.setValidStrings("recalculate_peaks", ListUtils::create<String>("true,false"));
 
-    defaults_.setValue("use_precursors", "false", "Use precursor chromatogram for peak picking", ListUtils::create<String>("advanced"));
+    defaults_.setValue("use_precursors", "false", "Use precursor chromatogram for peak picking (note that this may lead to precursor signal driving the peak picking)", ListUtils::create<String>("advanced"));
     defaults_.setValidStrings("use_precursors", ListUtils::create<String>("true,false"));
+
+    defaults_.setValue("use_consensus", "true", "Use consensus peak boundaries when computing transition group picking (if false, compute independent peak boundaries for each transition)", ListUtils::create<String>("advanced"));
+    defaults_.setValidStrings("use_consensus", ListUtils::create<String>("true,false"));
 
     defaults_.setValue("recalculate_peaks_max_z", 1.0, "Determines the maximal Z-Score (difference measured in standard deviations) that is considered too large for peak boundaries. If the Z-Score is above this value, the median is used for peak boundaries (default value 1.0).", ListUtils::create<String>("advanced"));
 
@@ -75,7 +78,7 @@ namespace OpenMS
     defaults_.setValue("compute_peak_quality", "false", "Tries to compute a quality value for each peakgroup and detect outlier transitions. The resulting score is centered around zero and values above 0 are generally good and below -1 or -2 are usually bad.", ListUtils::create<String>("advanced"));
     defaults_.setValidStrings("compute_peak_quality", ListUtils::create<String>("true,false"));
     
-    defaults_.setValue("compute_peak_shape_metrics", "false", "Calulates various peak shape metrics (e.g., tailing) that can be used for downstream QC/QA.", ListUtils::create<String>("advanced"));
+    defaults_.setValue("compute_peak_shape_metrics", "false", "Calculates various peak shape metrics (e.g., tailing) that can be used for downstream QC/QA.", ListUtils::create<String>("advanced"));
     defaults_.setValidStrings("compute_peak_shape_metrics", ListUtils::create<String>("true,false"));
 
     defaults_.setValue("boundary_selection_method", "largest", "Method to use when selecting the best boundaries for peaks.", ListUtils::create<String>("advanced"));
@@ -111,6 +114,7 @@ namespace OpenMS
     background_subtraction_ = param_.getValue("background_subtraction");
     recalculate_peaks_ = (bool)param_.getValue("recalculate_peaks").toBool();
     use_precursors_ = (bool)param_.getValue("use_precursors").toBool();
+    use_consensus_ = (bool)param_.getValue("use_consensus").toBool();
     recalculate_peaks_max_z_ = (double)param_.getValue("recalculate_peaks_max_z");
     compute_peak_quality_ = (bool)param_.getValue("compute_peak_quality").toBool();
     compute_peak_shape_metrics_ = (bool)param_.getValue("compute_peak_shape_metrics").toBool();


### PR DESCRIPTION
First idea on how we could have a per-transitiongroup peak boundaries

Basically we pick the highest intensity peak for each transition in the window and then use this going forward. This may be problematic if we have more than one peak in that window (e.g. the peaks may not match up well).