### PR TITLE
feat: add acq_method_name metavalue to ChromeleonFile parser

### DIFF
--- a/src/openms/source/FORMAT/ChromeleonFile.cpp
+++ b/src/openms/source/FORMAT/ChromeleonFile.cpp
@@ -48,6 +48,7 @@ namespace OpenMS
     experiment.clear(true);
     MSChromatogram chromatogram;
     boost::cmatch m;
+    boost::regex re_channel("^Channel\t(.+)", boost::regex::no_mod_s);
     boost::regex re_injection("^Injection\t(.+)", boost::regex::no_mod_s);
     boost::regex re_processing_method("^Processing Method\t(.+)", boost::regex::no_mod_s);
     boost::regex re_instrument_method("^Instrument Method\t(.+)", boost::regex::no_mod_s);
@@ -64,6 +65,10 @@ namespace OpenMS
       if (boost::regex_search(line, m, re_injection))
       {
         experiment.setMetaValue("mzml_id", std::string(m[1]));
+      }
+      else if (boost::regex_search(line, m, re_channel))
+      {
+        experiment.setMetaValue("acq_method_name", std::string(m[1]));
       }
       else if (boost::regex_search(line, m, re_processing_method))
       {

--- a/src/tests/class_tests/openms/source/ChromeleonFile_test.cpp
+++ b/src/tests/class_tests/openms/source/ChromeleonFile_test.cpp
@@ -71,6 +71,7 @@ START_SECTION(void load(const String& filename, MSExperiment& experiment) const)
 {
   MSExperiment experiment;
   ptr->load(input_filepath, experiment);
+  TEST_EQUAL(experiment.getMetaValue("acq_method_name"), "UV_VIS_2")
   TEST_EQUAL(experiment.getMetaValue("mzml_id"), "20171013_C61_ISO_P1_GA1")
   TEST_EQUAL(experiment.getExperimentalSettings().getInstrument().getName(), "HM_metode_ZorBax_0,02%_Acetic_acid_ver6")
   TEST_EQUAL(experiment.getExperimentalSettings().getInstrument().getSoftware().getName(), "New ProcMethod")


### PR DESCRIPTION
Does it look like what we need/want?

The `Channel` info is found twice within the file (the first time at line 2 of the file, and then within the raw information data). Same info repeated. The code would simply overwrite the first "set" value.