### PR TITLE
fix: ChromeleonFile can handle commas as thousands separator

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/ChromeleonFile.h
+++ b/src/openms/include/OpenMS/FORMAT/ChromeleonFile.h
@@ -67,6 +67,8 @@ public:
       @param[out] experiment The variable into which the extracted information will be saved
     */
     void load(const String& filename, MSExperiment& experiment) const;
+
+    double parseDouble(String number) const;
   };
 }
 

--- a/src/openms/source/FORMAT/ChromeleonFile.cpp
+++ b/src/openms/source/FORMAT/ChromeleonFile.cpp
@@ -113,11 +113,11 @@ namespace OpenMS
     while (!ifs.eof())
     {
       TextFile::getLine(ifs, line);
-      double rt, intensity;
-      int ret = std::sscanf(line.c_str(), "%lf\t%*s\t%lf", &rt, &intensity);
+      char rt[128], intensity[128];
+      int ret = std::sscanf(line.c_str(), "%s\t%*s\t%s", rt, intensity);
       if (ret == 2)
       {
-        chromatogram.push_back(ChromatogramPeak(rt, intensity));
+        chromatogram.push_back(ChromatogramPeak(parseDouble(rt), parseDouble(intensity)));
       }
       else if (line.empty())
       {
@@ -130,5 +130,10 @@ namespace OpenMS
     }
     ifs.close();
     experiment.addChromatogram(chromatogram);
+  }
+
+  double ChromeleonFile::parseDouble(String number) const
+  {
+    return number.remove(',').toDouble();
   }
 }

--- a/src/tests/class_tests/openms/data/ChromeleonFile_commas.txt
+++ b/src/tests/class_tests/openms/data/ChromeleonFile_commas.txt
@@ -1,0 +1,51 @@
+﻿File Path	chrom://aibn-gh359r2/ChromeleonLocal/Instrument Data/HPLC_2/SUG_190605_AXA_REINJ FOR ROBIN_MP.seq/904.smp/RID_Signal.channel/RID_Signal.chm
+Channel	RID_Signal
+
+Injection Information:
+Data Vault	ChromeleonLocal
+Injection	S2
+Injection Number	13
+Position	Vial:7
+Comment	
+Processing Method	SUGARS_CAL
+Instrument Method	SUGARS_MP.M
+Type	Calibration Standard
+Status	Finished
+Injection Date	12/06/2019
+Injection Time	11:49:36 PM
+Injection Volume (µL)	10.00
+Dilution Factor	1.0000
+Weight	1.0000
+
+Chromatogram Data Information:
+Time Min. (min)	0.000000
+Time Max. (min)	21.002886
+Data Points	2912
+Detector	LCSystem
+Generating Data System	Chromeleon 7.2.9.11323
+Exporting Data System	Chromeleon 7.2.9.0
+Operator	Instrument Controller
+Signal Quantity	
+Signal Unit	nRIU
+Signal Min.	-201.270000
+Signal Max.	33,047.790000
+Channel	RID_Signal
+Driver Name	ICF.dll
+Channel Type	Evaluation
+Min. Step (s)	0.43290043
+Max. Step (s)	0.43290043
+Average Step (s)	0.43290043
+
+Signal Parameter Information:
+Signal Info	
+
+Raw Data:
+Time (min)	Step (s)	Value (nRIU)
+0.0	0.0	1.400000
+8.300000	0.43290043	1.600000
+8.513709	0.43290043	-18.980000
+8.520924	0.43290043	-1,234,567.890000
+9.855700	0.43290043	1,946.610000
+9.884560	0.43290043	2,067.450000
+9.898991	0.43290043	2,345,678.900000
+9.920635	0.43290043	2,028.580000

--- a/src/tests/class_tests/openms/source/ChromeleonFile_test.cpp
+++ b/src/tests/class_tests/openms/source/ChromeleonFile_test.cpp
@@ -174,6 +174,45 @@ START_SECTION(load_with_new_raw_data_header)
 }
 END_SECTION
 
+START_SECTION(load_file_with_comma_thousands_separator)
+{
+  String input_filepath = OPENMS_GET_TEST_DATA_PATH("ChromeleonFile_commas.txt");
+  MSExperiment experiment;
+  ChromeleonFile cf;
+  cf.load(input_filepath, experiment);
+  TEST_EQUAL(experiment.getMetaValue("acq_method_name"), "RID_Signal")
+  TEST_EQUAL(experiment.getMetaValue("mzml_id"), "S2")
+  TEST_EQUAL(experiment.getExperimentalSettings().getInstrument().getName(), "SUGARS_MP.M")
+  TEST_EQUAL(experiment.getExperimentalSettings().getInstrument().getSoftware().getName(), "SUGARS_CAL")
+  TEST_EQUAL(experiment.getMetaValue("injection_date"), "12/06/2019")
+  TEST_EQUAL(experiment.getMetaValue("injection_time"), "11:49:36 PM")
+  TEST_EQUAL(experiment.getMetaValue("detector"), "LCSystem")
+  TEST_EQUAL(experiment.getMetaValue("signal_quantity"), "")
+  TEST_EQUAL(experiment.getMetaValue("signal_unit"), "nRIU")
+  TEST_EQUAL(experiment.getMetaValue("signal_info"), "")
+  const vector<MSChromatogram> chromatograms = experiment.getChromatograms();
+  TEST_EQUAL(chromatograms.size(), 1);
+  TEST_EQUAL(chromatograms[0].size(), 8);
+  const MSChromatogram& c = chromatograms[0];
+  TEST_REAL_SIMILAR(c[0].getRT(), 0.0)
+  TEST_REAL_SIMILAR(c[1].getRT(), 8.300000)
+  TEST_REAL_SIMILAR(c[2].getRT(), 8.513709)
+  TEST_REAL_SIMILAR(c[3].getRT(), 8.520924)
+  TEST_REAL_SIMILAR(c[4].getRT(), 9.855700)
+  TEST_REAL_SIMILAR(c[5].getRT(), 9.884560)
+  TEST_REAL_SIMILAR(c[6].getRT(), 9.898991)
+  TEST_REAL_SIMILAR(c[7].getRT(), 9.920635)
+  TEST_REAL_SIMILAR(c[0].getIntensity(), 1.4)
+  TEST_REAL_SIMILAR(c[1].getIntensity(), 1.6)
+  TEST_REAL_SIMILAR(c[2].getIntensity(), -18.980000)
+  TEST_REAL_SIMILAR(c[3].getIntensity(), -1234567.890000)
+  TEST_REAL_SIMILAR(c[4].getIntensity(), 1946.610000)
+  TEST_REAL_SIMILAR(c[5].getIntensity(), 2067.450000)
+  TEST_REAL_SIMILAR(c[6].getIntensity(), 2345678.900000)
+  TEST_REAL_SIMILAR(c[7].getIntensity(), 2028.580000)
+}
+END_SECTION
+
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 END_TEST


### PR DESCRIPTION
Tests and test's data file are ready. I will push them as soon as I have confirmation that I can publish them.

Note: the data file is a trimmed version of what you attached in the issue description. It has around 10 lines of data points.

Tests handle the following scenarios:
- commas as thousands separator
- dot `.` is still assumed to be the decimal separator
- large numbers (i.e. the comma shows up more than once), both positive and negative
- the data is correctly converted to `double`